### PR TITLE
Add p5.4xlarge instance and AWS Price List Bulk API documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,26 @@ AWS EC2 GPUインスタンスの比較表を表示する静的Webサイト。
  efaVersion, pcie, vcpu, memory, nvme, onDemandPrice, pricePerGpu, cbPrice, tokyoAvailable]
 ```
 
-### CB (Capacity Blocks) 価格更新
+### 価格更新
+
+#### On-Demand 価格
+
+**AWS Price List Bulk API**を使用して最新価格を取得可能:
+```
+https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json
+```
+
+- ファイルサイズが大きい（数百MB）ため、ダウンロードと解析に時間がかかる
+- `products` セクションでインスタンスタイプを検索
+- `terms.OnDemand` セクションで価格情報を取得
+- リージョン別の価格は `location` フィールドで識別
+- 東京リージョンは `"Asia Pacific (Tokyo)"` または `ap-northeast-1`
+
+**代替手段:**
+- AWS CLI: `aws pricing get-products --service-code AmazonEC2 --filters ...`
+- AWS SDKを使用したプログラマティックアクセス
+
+#### CB (Capacity Blocks) 価格更新
 
 CB価格データソース:
 https://raw.githubusercontent.com/koyakimu/ec2-capacity-blocks-for-ml-pricing-json/refs/heads/main/data/pricing.json

--- a/index.html
+++ b/index.html
@@ -272,9 +272,10 @@ const GPU_DATA = [
     { gen: 'blackwell', size: 'g7e.24xlarge', count: 4, vram: '384GB', fp16: '960*', fp8: '1,920*', est: true, efa: '-', pcie: 'Gen5', vcpu: 96, mem: '1TB', nvme: '7.6TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
     { gen: 'blackwell', size: 'g7e.48xlarge', count: 8, vram: '768GB', fp16: '1,920*', fp8: '3,840*', est: true, efa: '1600G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '15.2TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
     // Hopper
-    { gen: 'hopper', genRows: 3, gpu: 'H200', ec2: 'P5en', size: 'p5en.48xlarge', count: 8, vram: '1.1TB', fp16: '1,979', fp8: '3,958', efa: 'v3 3200G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$63.30', priceGpu: '$7.91', priceCb: '$5.20', tokyo: true },
+    { gen: 'hopper', genRows: 4, gpu: 'H200', ec2: 'P5en', size: 'p5en.48xlarge', count: 8, vram: '1.1TB', fp16: '1,979', fp8: '3,958', efa: 'v3 3200G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$63.30', priceGpu: '$7.91', priceCb: '$5.20', tokyo: true },
     { gen: 'hopper', gpu: 'H200', ec2: 'P5e', size: 'p5e.48xlarge', count: 8, vram: '1.1TB', fp16: '1,979', fp8: '3,958', efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: null, priceGpu: null, priceCb: '$4.98', tokyo: true },
-    { gen: 'hopper', gpu: 'H100', ec2: 'P5', size: 'p5.48xlarge', count: 8, vram: '640GB', fp16: '1,979', fp8: '3,958', efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$30.27', priceGpu: '$3.78', priceCb: '$3.93', tokyo: true },
+    { gen: 'hopper', gpu: 'H100', ec2: 'P5', ec2Rows: 2, size: 'p5.48xlarge', count: 8, vram: '640GB', fp16: '1,979', fp8: '3,958', efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$30.27', priceGpu: '$3.78', priceCb: '$3.93', tokyo: true },
+    { gen: 'hopper', size: 'p5.4xlarge', count: 1, vram: '80GB', fp16: '247', fp8: '495', efa: '-', pcie: 'Gen4', vcpu: 24, mem: '256GB', nvme: '3.8TB', price: '$3.78', priceGpu: '$3.78', priceCb: '-', tokyo: true },
 
     // Ada Lovelace - G6e L40S
     { gen: 'ada', genRows: 11, gpu: 'L40S', gpuRows: 4, ec2: 'G6e', ec2Rows: 4, size: 'g6e.xlarge', count: 1, vram: '48GB', fp16: '733', fp8: '1,466', efa: '-', pcie: 'Gen4', vcpu: 4, mem: '32GB', nvme: '-', price: '$1.86', priceGpu: '$1.86', priceCb: '-', tokyo: true },


### PR DESCRIPTION
## Summary

Adds the missing p5.4xlarge instance entry and documents AWS Price List Bulk API for future price updates.

## Changes

- Added p5.4xlarge entry with H100 GPU specifications (80GB VRAM, 24 vCPU, 256GB memory)
- Documented AWS Price List Bulk API usage in CLAUDE.md for On-Demand pricing
- Updated table structure (genRows and ec2Rows) for proper rendering

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)