### PR TITLE
Fix p5.4xlarge column alignment and add CB pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,8 +274,8 @@ const GPU_DATA = [
     // Hopper
     { gen: 'hopper', genRows: 4, gpu: 'H200', ec2: 'P5en', size: 'p5en.48xlarge', count: 8, vram: '1.1TB', fp16: '1,979', fp8: '3,958', efa: 'v3 3200G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$63.30', priceGpu: '$7.91', priceCb: '$5.20', tokyo: true },
     { gen: 'hopper', gpu: 'H200', ec2: 'P5e', size: 'p5e.48xlarge', count: 8, vram: '1.1TB', fp16: '1,979', fp8: '3,958', efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: null, priceGpu: null, priceCb: '$4.98', tokyo: true },
-    { gen: 'hopper', gpu: 'H100', ec2: 'P5', ec2Rows: 2, size: 'p5.48xlarge', count: 8, vram: '640GB', fp16: '1,979', fp8: '3,958', efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$30.27', priceGpu: '$3.78', priceCb: '$3.93', tokyo: true },
-    { gen: 'hopper', size: 'p5.4xlarge', count: 1, vram: '80GB', fp16: '247', fp8: '495', efa: '-', pcie: 'Gen4', vcpu: 24, mem: '256GB', nvme: '3.8TB', price: '$3.78', priceGpu: '$3.78', priceCb: '-', tokyo: true },
+    { gen: 'hopper', gpu: 'H100', gpuRows: 2, ec2: 'P5', ec2Rows: 2, size: 'p5.48xlarge', count: 8, vram: '640GB', fp16: '1,979', fp8: '3,958', efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$30.27', priceGpu: '$3.78', priceCb: '$3.93', tokyo: true },
+    { gen: 'hopper', size: 'p5.4xlarge', count: 1, vram: '80GB', fp16: '247', fp8: '495', efa: '-', pcie: 'Gen4', vcpu: 24, mem: '256GB', nvme: '3.8TB', price: '$3.78', priceGpu: '$3.78', priceCb: '$3.78', tokyo: true },
 
     // Ada Lovelace - G6e L40S
     { gen: 'ada', genRows: 11, gpu: 'L40S', gpuRows: 4, ec2: 'G6e', ec2Rows: 4, size: 'g6e.xlarge', count: 1, vram: '48GB', fp16: '733', fp8: '1,466', efa: '-', pcie: 'Gen4', vcpu: 4, mem: '32GB', nvme: '-', price: '$1.86', priceGpu: '$1.86', priceCb: '-', tokyo: true },


### PR DESCRIPTION
## Summary
- Fix column misalignment for p5.4xlarge row
- Add Capacity Blocks pricing for p5.4xlarge

## Changes
- Add `gpuRows: 2` to p5.48xlarge entry for proper H100 GPU cell spanning
- Add `priceCb: '$3.78'` to p5.4xlarge entry

Fixes #6

Generated with [Claude Code](https://claude.ai/code)