### PR TITLE
feat: GitHub ActionsのClaudeモデルをOpus 4.6に指定

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 30"
+          claude_args: "--model opus --max-turns 30"
 
   # PR 自動レビュー
   claude-review:
@@ -64,4 +64,4 @@ jobs:
             - コードの品質と可読性
             - 潜在的なバグやセキュリティ問題
             - CLAUDE.mdに記載されたプロジェクト規約との整合性
-          claude_args: "--max-turns 15"
+          claude_args: "--model opus --max-turns 15"


### PR DESCRIPTION
## Summary
- `claude-comment`ジョブと`claude-review`ジョブの`claude_args`に`--model opus`を追加
- `--model opus`を指定することで、将来新しいOpusモデルがリリースされた場合も自動的に最新版が使用される

Closes #14

## Test plan
- [ ] GitHub ActionsのワークフローYAML構文が正しいことを確認
- [ ] PRまたはissueで@claudeメンションした際にOpusモデルが使用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)