### PR TITLE
fix: G7eインスタンスのOn-Demand価格を更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,606 +1,1794 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AWS EC2 GPU インスタンス リファレンスガイド (2026年1月更新)</title>
-    
-    <!-- SEO -->
-    <meta name="description" content="AWS EC2 GPUインスタンスの完全比較ガイド。Blackwell〜Voltaまで全世代のスペック・価格・東京リージョン対応状況を一覧で確認。">
-    <meta name="keywords" content="AWS, EC2, GPU, NVIDIA, Blackwell, Hopper, H100, H200, P5, G6, 機械学習, AI, インスタンス比較">
-    <meta name="author" content="koyakimu">
-    
-    <!-- OGP (Open Graph Protocol) -->
-    <meta property="og:title" content="AWS EC2 GPU インスタンス リファレンスガイド">
-    <meta property="og:description" content="Blackwell〜Voltaまで全世代のGPUインスタンスを網羅。スペック・価格・東京リージョン対応を一覧比較。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://koyakimu.github.io/aws-gpu-quick-reference/">
-    <meta property="og:image" content="https://koyakimu.github.io/aws-gpu-quick-reference/ogp.png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
-    <meta property="og:locale" content="ja_JP">
-    <meta property="og:site_name" content="AWS EC2 GPU Reference Guide">
-    
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AWS EC2 GPU インスタンス リファレンスガイド">
-    <meta name="twitter:description" content="Blackwell〜Voltaまで全世代のGPUインスタンスを網羅。スペック・価格・東京リージョン対応を一覧比較。">
-    <meta name="twitter:image" content="https://koyakimu.github.io/aws-gpu-quick-reference/ogp.png">
-    
-    <!-- Favicon -->
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
-    <style>
-        :root {
-            /* AWS カラーパレット */
-            --aws-squid-ink: #232F3E;
-            --aws-squid-ink-dark: #1A242F;
-            --aws-squid-ink-deep: #131A22;
-            --aws-orange: #FF9900;
-            --aws-orange-light: #FFAC31;
-            --aws-orange-dark: #EC7211;
-            --aws-smile: #FF9900;
-            --aws-blue: #527FFF;
-            --aws-teal: #44B9C6;
-            --aws-green: #7AA116;
-            --aws-purple: #8C6EFF;
-
-            /* 世代別カラー（AWSカラーベース） */
-            --c-blackwell: 140, 110, 255;
-            --c-hopper: 82, 127, 255;
-            --c-ada: 68, 185, 198;
-            --c-ampere: 255, 153, 0;
-            --c-turing: 122, 161, 22;
-            --c-volta: 136, 153, 166;
-
-            /* UI カラー */
-            --c-accent: var(--aws-orange);
-            --c-price: #7AA116;
-            --c-cb: var(--aws-teal);
-            --c-inst: var(--aws-blue);
-            --c-efa: var(--aws-purple);
-            --c-pcie: #E07EAC;
-            --c-warn: var(--aws-orange-light);
-            --c-est: #FFD97D;
-            --c-ok: #7AA116;
-            --c-no: #D13212;
-
-            /* レイアウト */
-            --border-radius: 12px;
-        }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
-        body {
-            font-family: 'Amazon Ember', 'Segoe UI', 'Hiragino Sans', 'Meiryo', system-ui, sans-serif;
-            background: var(--aws-squid-ink-deep);
-            background-image:
-                radial-gradient(ellipse at 20% 50%, rgba(82, 127, 255, 0.06) 0%, transparent 50%),
-                radial-gradient(ellipse at 80% 20%, rgba(140, 110, 255, 0.05) 0%, transparent 50%),
-                radial-gradient(ellipse at 50% 100%, rgba(255, 153, 0, 0.04) 0%, transparent 40%);
-            color: #E8EAED;
-            min-height: 100vh;
-            padding: 24px;
-            line-height: 1.5;
-        }
-
-        .container { max-width: 100%; }
-
-        .table-wrapper {
-            overflow-x: auto;
-            border-radius: var(--border-radius);
-            border: 1px solid rgba(255, 153, 0, 0.15);
-            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.03);
-        }
-
-        h1 {
-            text-align: center;
-            margin-bottom: 8px;
-            color: var(--aws-orange);
-            font-size: 1.9em;
-            font-weight: 700;
-            letter-spacing: -0.02em;
-        }
-
-        .subtitle {
-            text-align: center;
-            color: #8899A6;
-            margin-bottom: 24px;
-            font-size: 0.95em;
-        }
-
-        /* 凡例 */
-        .legend {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 16px;
-            justify-content: center;
-            margin-bottom: 24px;
-            padding: 16px 20px;
-            background: rgba(255, 255, 255, 0.04);
-            border: 1px solid rgba(255, 255, 255, 0.06);
-            border-radius: var(--border-radius);
-        }
-
-        .legend-item {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-size: 0.9em;
-            color: #B0BEC5;
-        }
-
-        .legend-color {
-            width: 18px;
-            height: 18px;
-            border-radius: 5px;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-        }
-
-        /* 世代別グラデーション（凡例用） */
-        .blackwell { background: linear-gradient(135deg, rgb(var(--c-blackwell)), rgba(var(--c-blackwell), 0.7)); }
-        .hopper { background: linear-gradient(135deg, rgb(var(--c-hopper)), rgba(var(--c-hopper), 0.7)); }
-        .ada { background: linear-gradient(135deg, rgb(var(--c-ada)), rgba(var(--c-ada), 0.7)); }
-        .ampere { background: linear-gradient(135deg, rgb(var(--c-ampere)), rgba(var(--c-ampere), 0.7)); }
-        .turing { background: linear-gradient(135deg, rgb(var(--c-turing)), rgba(var(--c-turing), 0.7)); }
-        .volta { background: linear-gradient(135deg, rgb(var(--c-volta)), rgba(var(--c-volta), 0.7)); }
-
-        /* テーブル基本 */
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 0.875em;
-            background: rgba(26, 36, 47, 0.9);
-        }
-
-        th, td {
-            padding: 8px 10px;
-            text-align: center;
-            border: 1px solid rgba(255, 255, 255, 0.06);
-            white-space: nowrap;
-        }
-
-        th {
-            background: var(--aws-squid-ink);
-            color: #E8EAED;
-            font-weight: 600;
-            position: sticky;
-            top: 0;
-            z-index: 10;
-            font-size: 0.95em;
-            letter-spacing: 0.01em;
-            border-bottom: 2px solid rgba(255, 153, 0, 0.3);
-        }
-
-        th.group {
-            background: linear-gradient(180deg, rgba(255, 153, 0, 0.2), rgba(255, 153, 0, 0.1));
-            color: var(--aws-orange-light);
-            font-size: 0.85em;
-            text-transform: uppercase;
-            letter-spacing: 0.06em;
-            padding: 6px 10px;
-        }
-
-        tbody tr, tbody td { transition: all 0.15s ease; }
-
-        /* 世代別行背景 */
-        .row-blackwell td { background: rgba(var(--c-blackwell), 0.1); }
-        .row-hopper td { background: rgba(var(--c-hopper), 0.1); }
-        .row-ada td { background: rgba(var(--c-ada), 0.1); }
-        .row-ampere td { background: rgba(var(--c-ampere), 0.1); }
-        .row-turing td { background: rgba(var(--c-turing), 0.1); }
-        .row-volta td { background: rgba(var(--c-volta), 0.1); }
-
-        /* 偶数行で微妙にコントラスト */
-        tbody tr:nth-child(even) td { filter: brightness(1.05); }
-
-        /* ホバー時 */
-        td[rowspan].cell-hover { position: relative; }
-        .row-blackwell td.cell-hover, td.cell-hover-blackwell { background: rgba(var(--c-blackwell), 0.55) !important; color: #fff !important; }
-        .row-hopper td.cell-hover, td.cell-hover-hopper { background: rgba(var(--c-hopper), 0.55) !important; color: #fff !important; }
-        .row-ada td.cell-hover, td.cell-hover-ada { background: rgba(var(--c-ada), 0.55) !important; color: #fff !important; }
-        .row-ampere td.cell-hover, td.cell-hover-ampere { background: rgba(var(--c-ampere), 0.55) !important; color: #fff !important; }
-        .row-turing td.cell-hover, td.cell-hover-turing { background: rgba(var(--c-turing), 0.55) !important; color: #fff !important; }
-        .row-volta td.cell-hover, td.cell-hover-volta { background: rgba(var(--c-volta), 0.55) !important; color: #fff !important; }
-
-        /* セル装飾クラス */
-        .arch {
-            font-weight: 700;
-            text-align: center;
-            vertical-align: middle;
-            padding: 8px 12px;
-            font-size: 0.95em;
-            letter-spacing: 0.01em;
-        }
-
-        .gpu { font-weight: 600; color: var(--aws-orange-light); }
-        .inst { font-family: 'Consolas', 'Monaco', monospace; color: var(--c-inst); }
-        .price { color: var(--c-price); font-weight: 500; }
-        .cb { color: var(--c-cb); }
-        .cbo { color: var(--c-warn); font-size: 0.9em; }
-        .efa { color: var(--c-efa); }
-        .pcie { color: var(--c-pcie); }
-        .est { color: var(--c-est); font-style: italic; }
-        .ok { color: var(--c-ok); font-weight: 600; }
-        .no { color: var(--c-no); }
-
-        .badge {
-            display: inline-block;
-            padding: 2px 6px;
-            border-radius: 4px;
-            font-size: 0.65em;
-            font-weight: 700;
-            background: linear-gradient(135deg, var(--aws-orange-dark), var(--aws-orange));
-            color: white;
-            margin-left: 4px;
-            text-transform: uppercase;
-            letter-spacing: 0.04em;
-        }
-
-        a { color: inherit; text-decoration: none; }
-        a:hover { text-decoration: underline; opacity: 0.9; }
-        .ec2-link { color: var(--c-inst); }
-        .ec2-link:hover { color: #fff; }
-
-        /* $/GPU(CB)列の幅を制限 */
-        td.cb, th.cb-header {
-            max-width: 80px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        /* Notes */
-        .notes {
-            margin-top: 24px;
-            padding: 20px 24px;
-            background: rgba(255, 255, 255, 0.04);
-            border: 1px solid rgba(255, 255, 255, 0.06);
-            border-radius: var(--border-radius);
-            font-size: 0.9em;
-            line-height: 1.7;
-        }
-
-        .notes h3 {
-            color: var(--aws-orange);
-            margin-bottom: 12px;
-            font-size: 1.05em;
-        }
-
-        .notes ul { margin-left: 20px; }
-        .notes li { margin-bottom: 6px; color: #C5CDD5; }
-        .notes li strong { color: #E8EAED; }
-
-        /* スマホ対応 */
-        @media (max-width: 768px) {
-            body { padding: 12px; }
-
-            h1 { font-size: 1.4em; }
-
-            table { font-size: 0.85em; }
-
-            th, td { padding: 10px 6px; }
-
-            .table-wrapper { -webkit-overflow-scrolling: touch; }
-
-            .legend { flex-wrap: wrap; gap: 10px; padding: 12px; }
-
-            .notes { padding: 14px; font-size: 0.9em; }
-        }
-    </style>
-</head>
-<body>
-<div class="container">
-    <h1>🚀 AWS EC2 GPU インスタンス リファレンスガイド</h1>
-    <p class="subtitle">最終更新: 2026年1月31日 | 価格: 東京リージョン On-Demand (税抜)</p>
-
-    <div class="legend">
-        <div class="legend-item"><div class="legend-color blackwell"></div>Blackwell (2024)</div>
-        <div class="legend-item"><div class="legend-color hopper"></div>Hopper (2022)</div>
-        <div class="legend-item"><div class="legend-color ada"></div>Ada Lovelace (2022)</div>
-        <div class="legend-item"><div class="legend-color ampere"></div>Ampere (2020)</div>
-        <div class="legend-item"><div class="legend-color turing"></div>Turing (2018)</div>
-        <div class="legend-item"><div class="legend-color volta"></div>Volta (2017)</div>
-    </div>
-
-    <div class="table-wrapper">
-    <table>
-        <thead>
-            <tr>
-                <th colspan="4" class="group">インスタンス</th>
-                <th colspan="4" class="group">GPU性能</th>
-                <th colspan="2" class="group">接続</th>
-                <th colspan="3" class="group">システム</th>
-                <th colspan="3" class="group">価格</th>
-                <th class="group"></th>
-            </tr>
-            <tr>
-                <th>世代</th><th>GPU</th><th>EC2</th><th>サイズ</th>
-                <th>数</th><th>VRAM</th><th>FP16</th><th>FP8</th>
-                <th><a href="https://aws.amazon.com/hpc/efa/" target="_blank" title="Elastic Fabric Adapter">EFA</a></th><th>PCIe</th>
-                <th>vCPU</th><th>Mem</th><th>NVMe</th>
-                <th><a href="https://aws.amazon.com/ec2/pricing/on-demand/" target="_blank" title="EC2 On-Demand 料金">$/h</a></th><th>$/GPU</th><th class="cb-header"><a href="https://aws.amazon.com/ec2/capacityblocks/" target="_blank" title="Capacity Blocks for ML">$/GPU<br>(CB)</a></th>
-                <th>東京</th>
-            </tr>
-        </thead>
-        <tbody id="gpu-table-body"></tbody>
-    </table>
-    </div>
-
-    <div class="notes">
-        <h3>📝 Notes</h3>
-        <ul>
-            <li><strong>価格:</strong> 2025年6月の値下げ反映済み。東京リージョン On-Demand 価格 (USD)。CB = Capacity Blocks。TBD = 価格未発表。</li>
-            <li><strong>G7e (NEW):</strong> NVIDIA RTX PRO 6000 Blackwell Server Edition GPU搭載。G6eの2.3倍の推論性能、2倍のVRAM (96GB/GPU)。48xlargeのみEFA対応。現在 us-east-1/us-east-2 のみ。</li>
-            <li><strong>P5en vs P5e vs P5:</strong>
-                <ul>
-                    <li><strong>P5en:</strong> H200 + EFAv3 + PCIe Gen5 → 最新・最高性能、On-Demand利用可</li>
-                    <li><strong>P5e:</strong> H200 + EFAv2 + PCIe Gen4 → CB専用、P5enより低コスト</li>
-                    <li><strong>P5:</strong> H100 + EFAv2 + PCIe Gen4 → VRAM 640GB、最もコスパ良好</li>
-                </ul>
-            </li>
-            <li><strong>EFA:</strong> Elastic Fabric Adapter。マルチノード分散学習に必須。v4 > v3 > v2 > v1 の順で高性能。</li>
-            <li><strong>PCIe:</strong> Gen5はGen4の約2倍の帯域幅。CPU-GPU間のデータ転送速度に影響。</li>
-            <li><strong>推奨:</strong>
-                <ul>
-                    <li>大規模LLM学習: P6-B200/B300 (Blackwell) or P5en (H200)</li>
-                    <li>中規模学習/推論: P5 (H100) or G6e (L40S)</li>
-                    <li>GenAI推論/グラフィックス: G7e (RTX PRO 6000) - 70Bモデルを1GPUで実行可能</li>
-                    <li>推論/ファインチューニング: G6 (L4) or G5 (A10G)</li>
-                    <li>コスト重視の推論: G4dn (T4) or G5g (T4G/Graviton)</li>
-                </ul>
-            </li>
-            <li><strong>FP16/FP8:</strong> TFLOPS値（Sparsity有効時）。FP8は主にTransformer推論で使用。T4/V100はFP8非対応。<span class="est">*付きは予想値</span>（G6f: GPU分割比率から算出、G7e: AWSブログ記事からの情報でNVIDIA公式未確認）。</li>
-        </ul>
-        <h3 style="margin-top: 15px;">🔗 公式リファレンス</h3>
-        <ul>
-            <li><a href="https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing" target="_blank">EC2 Accelerated Computing インスタンス一覧</a></li>
-            <li><a href="https://aws.amazon.com/ec2/pricing/on-demand/" target="_blank">EC2 On-Demand 料金</a></li>
-            <li><a href="https://aws.amazon.com/ec2/capacityblocks/" target="_blank">Capacity Blocks for ML</a></li>
-            <li><a href="https://aws.amazon.com/hpc/efa/" target="_blank">Elastic Fabric Adapter (EFA)</a></li>
-            <li><a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html" target="_blank">EC2 ユーザーガイド - アクセラレーテッドコンピューティング</a></li>
-            <li><a href="https://aws.amazon.com/blogs/aws/category/compute/amazon-ec2/" target="_blank">AWS Blog - EC2 カテゴリ（最新情報）</a></li>
-        </ul>
-        <h3 style="margin-top: 15px;">⚠️ 免責事項</h3>
-        <p style="color: #fdcb6e; font-size: 0.9em; line-height: 1.6;">
-            本ページの情報は参考用であり、正確性を保証するものではありません。価格・仕様・リージョン対応状況は予告なく変更される場合があります。
-            最新かつ正確な情報については、必ず<a href="https://aws.amazon.com/ec2/instance-types/" target="_blank" style="color: #74b9ff;">AWS公式ドキュメント</a>をご確認ください。
-            本ページの情報に基づく判断・行動によって生じた損害について、作成者は一切の責任を負いません。
-        </p>
-    </div>
-</div>
-
-<script>
-// EC2タイプからAWS公式ページURLを生成
-const EC2_LINKS = {
-    'P6-B300': 'https://aws.amazon.com/ec2/instance-types/p6/',
-    'P6-B200': 'https://aws.amazon.com/ec2/instance-types/p6/',
-    'G7e': 'https://aws.amazon.com/ec2/instance-types/g7e/',
-    'P5en': 'https://aws.amazon.com/ec2/instance-types/p5/',
-    'P5e': 'https://aws.amazon.com/ec2/instance-types/p5/',
-    'P5': 'https://aws.amazon.com/ec2/instance-types/p5/',
-    'G6e': 'https://aws.amazon.com/ec2/instance-types/g6e/',
-    'G6': 'https://aws.amazon.com/ec2/instance-types/g6/',
-    'G6f': 'https://aws.amazon.com/ec2/instance-types/g6/',
-    'P4d': 'https://aws.amazon.com/ec2/instance-types/p4/',
-    'P4de': 'https://aws.amazon.com/ec2/instance-types/p4/',
-    'G5': 'https://aws.amazon.com/ec2/instance-types/g5/',
-    'G4dn': 'https://aws.amazon.com/ec2/instance-types/g4/',
-    'G5g': 'https://aws.amazon.com/ec2/instance-types/g5g/',
-    'P3': 'https://aws.amazon.com/ec2/instance-types/p3/',
-    'P3dn': 'https://aws.amazon.com/ec2/instance-types/p3/',
-};
-
-// GPU インスタンスデータ
-// count: GPU数、vramPerGpu: 1GPU当たりのVRAM、fp16PerGpu/fp8PerGpu: 1GPU当たりの性能
-const GPU_DATA = [
-    // Blackwell
-    { gen: 'blackwell', genRows: 8, gpu: 'B300', gpuNew: true, ec2: 'P6-B300', size: 'p6-b300.48xlarge', count: 8, vramPerGpu: 288, fp16PerGpu: 2250, fp8PerGpu: 4500, efa: 'v4 3200G', pcie: 'Gen5', vcpu: 192, mem: '4TB', nvme: '30TB', price: null, priceGpu: null, priceCb: '$11.70', tokyo: false },
-    { gen: 'blackwell', gpu: 'B200', ec2: 'P6-B200', size: 'p6-b200.48xlarge', count: 8, vramPerGpu: 180, fp16PerGpu: 2250, fp8PerGpu: 4500, efa: 'v4 3200G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '30TB', price: null, priceGpu: null, priceCb: '$9.36', tokyo: false },
-    { gen: 'blackwell', gpu: 'RTX PRO', gpuNew: true, gpuRows: 6, ec2: 'G7e', ec2Rows: 6, size: 'g7e.2xlarge', count: 1, vramPerGpu: 96, fp16PerGpu: 240, fp8PerGpu: 480, est: true, efa: '-', pcie: 'Gen5', vcpu: 8, mem: '64GB', nvme: '1.9TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
-    { gen: 'blackwell', size: 'g7e.4xlarge', count: 1, vramPerGpu: 96, fp16PerGpu: 240, fp8PerGpu: 480, est: true, efa: '-', pcie: 'Gen5', vcpu: 16, mem: '128GB', nvme: '1.9TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
-    { gen: 'blackwell', size: 'g7e.8xlarge', count: 1, vramPerGpu: 96, fp16PerGpu: 240, fp8PerGpu: 480, est: true, efa: '-', pcie: 'Gen5', vcpu: 32, mem: '256GB', nvme: '1.9TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
-    { gen: 'blackwell', size: 'g7e.12xlarge', count: 2, vramPerGpu: 96, fp16PerGpu: 240, fp8PerGpu: 480, est: true, efa: '-', pcie: 'Gen5', vcpu: 48, mem: '512GB', nvme: '3.8TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
-    { gen: 'blackwell', size: 'g7e.24xlarge', count: 4, vramPerGpu: 96, fp16PerGpu: 240, fp8PerGpu: 480, est: true, efa: '-', pcie: 'Gen5', vcpu: 96, mem: '1TB', nvme: '7.6TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
-    { gen: 'blackwell', size: 'g7e.48xlarge', count: 8, vramPerGpu: 96, fp16PerGpu: 240, fp8PerGpu: 480, est: true, efa: '1600G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '15.2TB', price: 'TBD', priceGpu: 'TBD', priceCb: '-', tokyo: false },
-    // Hopper
-    { gen: 'hopper', genRows: 4, gpu: 'H200', ec2: 'P5en', size: 'p5en.48xlarge', count: 8, vramPerGpu: 141, fp16PerGpu: 1979, fp8PerGpu: 3958, efa: 'v3 3200G', pcie: 'Gen5', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$63.30', priceGpu: '$7.91', priceCb: '$5.20', tokyo: true },
-    { gen: 'hopper', gpu: 'H200', ec2: 'P5e', size: 'p5e.48xlarge', count: 8, vramPerGpu: 141, fp16PerGpu: 1979, fp8PerGpu: 3958, efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: null, priceGpu: null, priceCb: '$4.98', tokyo: true },
-    { gen: 'hopper', gpu: 'H100', gpuRows: 2, ec2: 'P5', ec2Rows: 2, size: 'p5.48xlarge', count: 8, vramPerGpu: 80, fp16PerGpu: 1979, fp8PerGpu: 3958, efa: 'v2 3200G', pcie: 'Gen4', vcpu: 192, mem: '2TB', nvme: '30TB', price: '$30.27', priceGpu: '$3.78', priceCb: '$3.93', tokyo: true },
-    { gen: 'hopper', size: 'p5.4xlarge', count: 1, vramPerGpu: 80, fp16PerGpu: 1979, fp8PerGpu: 3958, efa: '-', pcie: 'Gen4', vcpu: 24, mem: '256GB', nvme: '3.8TB', price: '$3.78', priceGpu: '$3.78', priceCb: '$3.78', tokyo: true },
-
-    // Ada Lovelace - G6e L40S
-    { gen: 'ada', genRows: 11, gpu: 'L40S', gpuRows: 4, ec2: 'G6e', ec2Rows: 4, size: 'g6e.xlarge', count: 1, vramPerGpu: 48, fp16PerGpu: 733, fp8PerGpu: 1466, efa: '-', pcie: 'Gen4', vcpu: 4, mem: '32GB', nvme: '-', price: '$1.86', priceGpu: '$1.86', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6e.4xlarge', count: 1, vramPerGpu: 48, fp16PerGpu: 733, fp8PerGpu: 1466, efa: '-', pcie: 'Gen4', vcpu: 16, mem: '128GB', nvme: '-', price: '$3.00', priceGpu: '$3.00', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6e.12xlarge', count: 4, vramPerGpu: 48, fp16PerGpu: 733, fp8PerGpu: 1466, efa: '-', pcie: 'Gen4', vcpu: 48, mem: '384GB', nvme: '-', price: '$10.49', priceGpu: '$2.62', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6e.48xlarge', count: 8, vramPerGpu: 48, fp16PerGpu: 733, fp8PerGpu: 1466, efa: '-', pcie: 'Gen4', vcpu: 192, mem: '1.5TB', nvme: '-', price: '$30.13', priceGpu: '$3.77', priceCb: '-', tokyo: true },
-    // Ada - G6 L4
-    { gen: 'ada', gpu: 'L4', gpuRows: 4, ec2: 'G6', ec2Rows: 4, size: 'g6.xlarge', count: 1, vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, efa: '-', pcie: 'Gen4', vcpu: 4, mem: '16GB', nvme: '-', price: '$0.80', priceGpu: '$0.80', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6.4xlarge', count: 1, vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, efa: '-', pcie: 'Gen4', vcpu: 16, mem: '64GB', nvme: '-', price: '$1.32', priceGpu: '$1.32', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6.12xlarge', count: 4, vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, efa: '-', pcie: 'Gen4', vcpu: 48, mem: '192GB', nvme: '-', price: '$4.60', priceGpu: '$1.15', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6.48xlarge', count: 8, vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, efa: '-', pcie: 'Gen4', vcpu: 192, mem: '768GB', nvme: '-', price: '$13.35', priceGpu: '$1.67', priceCb: '-', tokyo: true },
-    // Ada - G6f L4
-    { gen: 'ada', gpu: 'L4', gpuRows: 3, ec2: 'G6f', ec2Rows: 3, size: 'g6f.large', count: '1/8', vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, est: true, efa: '-', pcie: 'Gen4', vcpu: 2, mem: '6GB', nvme: '-', price: '$0.20', priceGpu: '$1.60', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6f.xlarge', count: '1/8', vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, est: true, efa: '-', pcie: 'Gen4', vcpu: 4, mem: '16GB', nvme: '-', price: '$0.24', priceGpu: '$1.92', priceCb: '-', tokyo: true },
-    { gen: 'ada', size: 'g6f.4xlarge', count: '1/2', vramPerGpu: 24, fp16PerGpu: 242, fp8PerGpu: 485, est: true, efa: '-', pcie: 'Gen4', vcpu: 16, mem: '64GB', nvme: '-', price: '$0.95', priceGpu: '$1.90', priceCb: '-', tokyo: true },
-    // Ampere
-    { gen: 'ampere', genRows: 9, gpu: 'A100 40GB', ec2: 'P4d', size: 'p4d.24xlarge', count: 8, vramPerGpu: 40, fp16PerGpu: 312, fp8PerGpu: null, efa: 'v1 400G', pcie: 'Gen4', vcpu: 96, mem: '1.1TB', nvme: '8TB', price: '$14.71', priceGpu: '$1.84', priceCb: '$1.48', tokyo: true },
-    { gen: 'ampere', gpu: 'A100 80GB', ec2: 'P4de', size: 'p4de.24xlarge', count: 8, vramPerGpu: 80, fp16PerGpu: 312, fp8PerGpu: null, efa: 'v1 400G', pcie: 'Gen4', vcpu: 96, mem: '1.1TB', nvme: '8TB', price: '$18.40', priceGpu: '$2.30', priceCb: '$1.85', tokyo: false },
-    { gen: 'ampere', gpu: 'A10G', gpuRows: 7, ec2: 'G5', ec2Rows: 7, size: 'g5.xlarge', count: 1, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 4, mem: '16GB', nvme: '125GB', price: '$1.01', priceGpu: '$1.01', priceCb: '-', tokyo: true },
-    { gen: 'ampere', size: 'g5.2xlarge', count: 1, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 8, mem: '32GB', nvme: '450GB', price: '$1.21', priceGpu: '$1.21', priceCb: '-', tokyo: true },
-    { gen: 'ampere', size: 'g5.4xlarge', count: 1, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 16, mem: '64GB', nvme: '600GB', price: '$1.62', priceGpu: '$1.62', priceCb: '-', tokyo: true },
-    { gen: 'ampere', size: 'g5.8xlarge', count: 1, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 32, mem: '128GB', nvme: '900GB', price: '$2.45', priceGpu: '$2.45', priceCb: '-', tokyo: true },
-    { gen: 'ampere', size: 'g5.12xlarge', count: 4, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 48, mem: '192GB', nvme: '3.8TB', price: '$5.67', priceGpu: '$1.42', priceCb: '-', tokyo: true },
-    { gen: 'ampere', size: 'g5.24xlarge', count: 4, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 96, mem: '384GB', nvme: '3.8TB', price: '$8.14', priceGpu: '$2.04', priceCb: '-', tokyo: true },
-    { gen: 'ampere', size: 'g5.48xlarge', count: 8, vramPerGpu: 24, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen4', vcpu: 192, mem: '768GB', nvme: '7.6TB', price: '$16.29', priceGpu: '$2.04', priceCb: '-', tokyo: true },
-
-    // Turing - G4dn T4
-    { gen: 'turing', genRows: 11, gpu: 'T4', gpuRows: 6, ec2: 'G4dn', ec2Rows: 6, size: 'g4dn.xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 4, mem: '16GB', nvme: '125GB', price: '$0.53', priceGpu: '$0.53', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g4dn.2xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 8, mem: '32GB', nvme: '225GB', price: '$0.75', priceGpu: '$0.75', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g4dn.4xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 16, mem: '64GB', nvme: '225GB', price: '$1.20', priceGpu: '$1.20', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g4dn.8xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 32, mem: '128GB', nvme: '900GB', price: '$2.18', priceGpu: '$2.18', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g4dn.12xlarge', count: 4, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 48, mem: '192GB', nvme: '900GB', price: '$3.91', priceGpu: '$0.98', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g4dn.metal', count: 8, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 96, mem: '384GB', nvme: '1.8TB', price: '$7.82', priceGpu: '$0.98', priceCb: '-', tokyo: true },
-    // Turing - G5g T4G
-    { gen: 'turing', gpu: 'T4G', gpuRows: 5, ec2: 'G5g', ec2Rows: 5, size: 'g5g.xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 4, mem: '8GB', nvme: '-', price: '$0.42', priceGpu: '$0.42', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g5g.2xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 8, mem: '16GB', nvme: '-', price: '$0.56', priceGpu: '$0.56', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g5g.4xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 16, mem: '32GB', nvme: '-', price: '$0.83', priceGpu: '$0.83', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g5g.8xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 32, mem: '64GB', nvme: '-', price: '$1.37', priceGpu: '$1.37', priceCb: '-', tokyo: true },
-    { gen: 'turing', size: 'g5g.16xlarge', count: 2, vramPerGpu: 16, fp16PerGpu: 65, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 64, mem: '128GB', nvme: '-', price: '$2.74', priceGpu: '$1.37', priceCb: '-', tokyo: true },
-    // Volta
-    { gen: 'volta', genRows: 4, gpu: 'V100', gpuRows: 4, ec2: 'P3', ec2Rows: 3, size: 'p3.2xlarge', count: 1, vramPerGpu: 16, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 8, mem: '61GB', nvme: '-', price: '$3.06', priceGpu: '$3.06', priceCb: '-', tokyo: true },
-    { gen: 'volta', size: 'p3.8xlarge', count: 4, vramPerGpu: 16, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 32, mem: '244GB', nvme: '-', price: '$12.24', priceGpu: '$3.06', priceCb: '-', tokyo: true },
-    { gen: 'volta', size: 'p3.16xlarge', count: 8, vramPerGpu: 16, fp16PerGpu: 125, fp8PerGpu: null, efa: '-', pcie: 'Gen3', vcpu: 64, mem: '488GB', nvme: '-', price: '$24.48', priceGpu: '$3.06', priceCb: '-', tokyo: true },
-    { gen: 'volta', ec2: 'P3dn', size: 'p3dn.24xlarge', count: 8, vramPerGpu: 32, fp16PerGpu: 125, fp8PerGpu: null, efa: '100G', pcie: 'Gen3', vcpu: 96, mem: '768GB', nvme: '1.8TB', price: '$31.21', priceGpu: '$3.90', priceCb: '-', tokyo: true },
-];
-
-const GEN_LABELS = { blackwell: 'Blackwell', hopper: 'Hopper', ada: 'Ada', ampere: 'Ampere', turing: 'Turing', volta: 'Volta' };
-
-// 数値のフォーマット関数（カンマ区切り）
-function formatNumber(num) {
-    return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-}
-
-// VRAM表示の生成（1GPU当たり + 合計）
-function formatVram(vramPerGpu, count) {
-    // G6fの分数表記の場合
-    if (typeof count === 'string' && count.includes('/')) {
-        const fraction = eval(count); // 1/8 → 0.125
-        const totalVram = vramPerGpu * fraction;
-        return `${totalVram}GB`;
-    }
-
-    const numCount = typeof count === 'number' ? count : parseInt(count);
-
-    if (numCount === 1) {
-        return `${vramPerGpu}GB`;
-    }
-
-    const totalGb = vramPerGpu * numCount;
-
-    // 1TB以上の場合はTB表記
-    if (totalGb >= 1000) {
-        const totalTb = (totalGb / 1000).toFixed(1);
-        return `${vramPerGpu}GB<br><small>(${totalTb}TB)</small>`;
-    }
-
-    return `${vramPerGpu}GB<br><small>(${totalGb}GB)</small>`;
-}
-
-// 性能表示の生成（1GPU当たり + 合計）
-function formatPerf(perfPerGpu, count, est = false) {
-    if (perfPerGpu === null) return '-';
-
-    // G6fの分数表記の場合
-    if (typeof count === 'string' && count.includes('/')) {
-        const fraction = eval(count);
-        const totalPerf = Math.round(perfPerGpu * fraction);
-        return `${est ? totalPerf + '*' : totalPerf}`;
-    }
-
-    const numCount = typeof count === 'number' ? count : parseInt(count);
-
-    if (numCount === 1) {
-        return `${est ? formatNumber(perfPerGpu) + '*' : formatNumber(perfPerGpu)}`;
-    }
-
-    const totalPerf = perfPerGpu * numCount;
-    return `${formatNumber(perfPerGpu)}<br><small>(${formatNumber(totalPerf)})</small>${est ? '*' : ''}`;
-}
-
-// テーブル生成
-function renderTable() {
-    const tbody = document.getElementById('gpu-table-body');
-    let html = '';
-
-    GPU_DATA.forEach((row, i) => {
-        const rowClass = `row-${row.gen}`;
-        html += `<tr class="${rowClass}">`;
-
-        // 世代セル
-        if (row.genRows) {
-            html += `<td class="arch" rowspan="${row.genRows}">${GEN_LABELS[row.gen]}</td>`;
-        }
-        // GPUセル
-        if (row.gpu) {
-            const badge = row.gpuNew ? '<span class="badge">NEW</span>' : '';
-            const rs = row.gpuRows ? ` rowspan="${row.gpuRows}"` : '';
-            html += `<td class="gpu"${rs}>${row.gpu}${badge}</td>`;
-        }
-        // EC2セル（リンク付き）
-        if (row.ec2) {
-            const rs = row.ec2Rows ? ` rowspan="${row.ec2Rows}"` : '';
-            const link = EC2_LINKS[row.ec2] || '#';
-            html += `<td${rs}><a href="${link}" target="_blank" class="ec2-link" title="${row.ec2} インスタンス詳細">${row.ec2}</a></td>`;
-        }
-        // サイズ
-        html += `<td class="inst">${row.size}</td>`;
-        // GPU数
-        html += `<td>${row.count}</td>`;
-        // VRAM（1GPU当たり + 合計）
-        html += `<td>${formatVram(row.vramPerGpu, row.count)}</td>`;
-        // FP16（1GPU当たり + 合計）
-        const estClass = row.est ? ' class="est"' : '';
-        html += `<td${estClass}>${formatPerf(row.fp16PerGpu, row.count, row.est)}</td>`;
-        // FP8（1GPU当たり + 合計）
-        html += `<td${estClass}>${formatPerf(row.fp8PerGpu, row.count, row.est)}</td>`;
-        // EFA, PCIe
-        html += `<td class="efa">${row.efa}</td><td class="pcie">${row.pcie}</td>`;
-        // vCPU, Mem, NVMe
-        html += `<td>${row.vcpu}</td><td>${row.mem}</td><td>${row.nvme}</td>`;
-        // 価格
-        const priceClass = row.price && row.price !== 'TBD' ? 'price' : 'cbo';
-        html += `<td class="${priceClass}">${row.price || 'CB専用'}</td>`;
-        html += `<td class="${priceClass}">${row.priceGpu || '-'}</td>`;
-        html += `<td class="cb">${row.priceCb}</td>`;
-        // 東京
-        html += `<td class="${row.tokyo ? 'ok' : 'no'}">${row.tokyo ? '◯' : '✕'}</td>`;
-        html += '</tr>';
-    });
-
-    tbody.innerHTML = html;
-}
-
-// ホバーエフェクト
-function setupHover() {
-    const rows = document.querySelectorAll('tbody tr');
-    const spanningCells = [];
-
-    // rowspanセル収集
-    rows.forEach((row, i) => {
-        const gen = row.className.replace('row-', '');
-        row.querySelectorAll('td[rowspan]').forEach(cell => {
-            spanningCells.push({
-                cell,
-                startRow: i,
-                endRow: i + parseInt(cell.getAttribute('rowspan')) - 1,
-                gen
-            });
-        });
-    });
-
-    rows.forEach((row, rowIndex) => {
-        const gen = row.className.replace('row-', '');
-        const hoverClass = `cell-hover-${gen}`;
-
-        row.addEventListener('mouseenter', () => {
-            row.querySelectorAll('td').forEach(td => td.classList.add('cell-hover'));
-            spanningCells.forEach(sc => {
-                if (rowIndex >= sc.startRow && rowIndex <= sc.endRow) {
-                    sc.cell.classList.add(`cell-hover-${sc.gen}`);
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>
+            AWS EC2 GPU インスタンス リファレンスガイド (2026年1月更新)
+        </title>
+
+        <!-- SEO -->
+        <meta
+            name="description"
+            content="AWS EC2 GPUインスタンスの完全比較ガイド。Blackwell〜Voltaまで全世代のスペック・価格・東京リージョン対応状況を一覧で確認。"
+        />
+        <meta
+            name="keywords"
+            content="AWS, EC2, GPU, NVIDIA, Blackwell, Hopper, H100, H200, P5, G6, 機械学習, AI, インスタンス比較"
+        />
+        <meta name="author" content="koyakimu" />
+
+        <!-- OGP (Open Graph Protocol) -->
+        <meta
+            property="og:title"
+            content="AWS EC2 GPU インスタンス リファレンスガイド"
+        />
+        <meta
+            property="og:description"
+            content="Blackwell〜Voltaまで全世代のGPUインスタンスを網羅。スペック・価格・東京リージョン対応を一覧比較。"
+        />
+        <meta property="og:type" content="website" />
+        <meta
+            property="og:url"
+            content="https://koyakimu.github.io/aws-gpu-quick-reference/"
+        />
+        <meta
+            property="og:image"
+            content="https://koyakimu.github.io/aws-gpu-quick-reference/ogp.png"
+        />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:locale" content="ja_JP" />
+        <meta property="og:site_name" content="AWS EC2 GPU Reference Guide" />
+
+        <!-- Twitter Card -->
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+            name="twitter:title"
+            content="AWS EC2 GPU インスタンス リファレンスガイド"
+        />
+        <meta
+            name="twitter:description"
+            content="Blackwell〜Voltaまで全世代のGPUインスタンスを網羅。スペック・価格・東京リージョン対応を一覧比較。"
+        />
+        <meta
+            name="twitter:image"
+            content="https://koyakimu.github.io/aws-gpu-quick-reference/ogp.png"
+        />
+
+        <!-- Favicon -->
+        <link
+            rel="icon"
+            href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>"
+        />
+        <style>
+            :root {
+                /* AWS カラーパレット */
+                --aws-squid-ink: #232f3e;
+                --aws-squid-ink-dark: #1a242f;
+                --aws-squid-ink-deep: #131a22;
+                --aws-orange: #ff9900;
+                --aws-orange-light: #ffac31;
+                --aws-orange-dark: #ec7211;
+                --aws-smile: #ff9900;
+                --aws-blue: #527fff;
+                --aws-teal: #44b9c6;
+                --aws-green: #7aa116;
+                --aws-purple: #8c6eff;
+
+                /* 世代別カラー（AWSカラーベース） */
+                --c-blackwell: 140, 110, 255;
+                --c-hopper: 82, 127, 255;
+                --c-ada: 68, 185, 198;
+                --c-ampere: 255, 153, 0;
+                --c-turing: 122, 161, 22;
+                --c-volta: 136, 153, 166;
+
+                /* UI カラー */
+                --c-accent: var(--aws-orange);
+                --c-price: #7aa116;
+                --c-cb: var(--aws-teal);
+                --c-inst: var(--aws-blue);
+                --c-efa: var(--aws-purple);
+                --c-pcie: #e07eac;
+                --c-warn: var(--aws-orange-light);
+                --c-est: #ffd97d;
+                --c-ok: #7aa116;
+                --c-no: #d13212;
+
+                /* レイアウト */
+                --border-radius: 12px;
+            }
+
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+
+            body {
+                font-family:
+                    "Amazon Ember", "Segoe UI", "Hiragino Sans", "Meiryo",
+                    system-ui, sans-serif;
+                background: var(--aws-squid-ink-deep);
+                background-image:
+                    radial-gradient(
+                        ellipse at 20% 50%,
+                        rgba(82, 127, 255, 0.06) 0%,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        ellipse at 80% 20%,
+                        rgba(140, 110, 255, 0.05) 0%,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        ellipse at 50% 100%,
+                        rgba(255, 153, 0, 0.04) 0%,
+                        transparent 40%
+                    );
+                color: #e8eaed;
+                min-height: 100vh;
+                padding: 24px;
+                line-height: 1.5;
+            }
+
+            .container {
+                max-width: 100%;
+            }
+
+            .table-wrapper {
+                overflow-x: auto;
+                border-radius: var(--border-radius);
+                border: 1px solid rgba(255, 153, 0, 0.15);
+                box-shadow:
+                    0 4px 24px rgba(0, 0, 0, 0.3),
+                    0 0 0 1px rgba(255, 255, 255, 0.03);
+            }
+
+            h1 {
+                text-align: center;
+                margin-bottom: 8px;
+                color: var(--aws-orange);
+                font-size: 1.9em;
+                font-weight: 700;
+                letter-spacing: -0.02em;
+            }
+
+            .subtitle {
+                text-align: center;
+                color: #8899a6;
+                margin-bottom: 24px;
+                font-size: 0.95em;
+            }
+
+            /* 凡例 */
+            .legend {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 16px;
+                justify-content: center;
+                margin-bottom: 24px;
+                padding: 16px 20px;
+                background: rgba(255, 255, 255, 0.04);
+                border: 1px solid rgba(255, 255, 255, 0.06);
+                border-radius: var(--border-radius);
+            }
+
+            .legend-item {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                font-size: 0.9em;
+                color: #b0bec5;
+            }
+
+            .legend-color {
+                width: 18px;
+                height: 18px;
+                border-radius: 5px;
+                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+            }
+
+            /* 世代別グラデーション（凡例用） */
+            .blackwell {
+                background: linear-gradient(
+                    135deg,
+                    rgb(var(--c-blackwell)),
+                    rgba(var(--c-blackwell), 0.7)
+                );
+            }
+            .hopper {
+                background: linear-gradient(
+                    135deg,
+                    rgb(var(--c-hopper)),
+                    rgba(var(--c-hopper), 0.7)
+                );
+            }
+            .ada {
+                background: linear-gradient(
+                    135deg,
+                    rgb(var(--c-ada)),
+                    rgba(var(--c-ada), 0.7)
+                );
+            }
+            .ampere {
+                background: linear-gradient(
+                    135deg,
+                    rgb(var(--c-ampere)),
+                    rgba(var(--c-ampere), 0.7)
+                );
+            }
+            .turing {
+                background: linear-gradient(
+                    135deg,
+                    rgb(var(--c-turing)),
+                    rgba(var(--c-turing), 0.7)
+                );
+            }
+            .volta {
+                background: linear-gradient(
+                    135deg,
+                    rgb(var(--c-volta)),
+                    rgba(var(--c-volta), 0.7)
+                );
+            }
+
+            /* テーブル基本 */
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 0.875em;
+                background: rgba(26, 36, 47, 0.9);
+            }
+
+            th,
+            td {
+                padding: 8px 10px;
+                text-align: center;
+                border: 1px solid rgba(255, 255, 255, 0.06);
+                white-space: nowrap;
+            }
+
+            th {
+                background: var(--aws-squid-ink);
+                color: #e8eaed;
+                font-weight: 600;
+                position: sticky;
+                top: 0;
+                z-index: 10;
+                font-size: 0.95em;
+                letter-spacing: 0.01em;
+                border-bottom: 2px solid rgba(255, 153, 0, 0.3);
+            }
+
+            th.group {
+                background: linear-gradient(
+                    180deg,
+                    rgba(255, 153, 0, 0.2),
+                    rgba(255, 153, 0, 0.1)
+                );
+                color: var(--aws-orange-light);
+                font-size: 0.85em;
+                text-transform: uppercase;
+                letter-spacing: 0.06em;
+                padding: 6px 10px;
+            }
+
+            tbody tr,
+            tbody td {
+                transition: all 0.15s ease;
+            }
+
+            /* 世代別行背景 */
+            .row-blackwell td {
+                background: rgba(var(--c-blackwell), 0.1);
+            }
+            .row-hopper td {
+                background: rgba(var(--c-hopper), 0.1);
+            }
+            .row-ada td {
+                background: rgba(var(--c-ada), 0.1);
+            }
+            .row-ampere td {
+                background: rgba(var(--c-ampere), 0.1);
+            }
+            .row-turing td {
+                background: rgba(var(--c-turing), 0.1);
+            }
+            .row-volta td {
+                background: rgba(var(--c-volta), 0.1);
+            }
+
+            /* 偶数行で微妙にコントラスト */
+            tbody tr:nth-child(even) td {
+                filter: brightness(1.05);
+            }
+
+            /* ホバー時 */
+            td[rowspan].cell-hover {
+                position: relative;
+            }
+            .row-blackwell td.cell-hover,
+            td.cell-hover-blackwell {
+                background: rgba(var(--c-blackwell), 0.55) !important;
+                color: #fff !important;
+            }
+            .row-hopper td.cell-hover,
+            td.cell-hover-hopper {
+                background: rgba(var(--c-hopper), 0.55) !important;
+                color: #fff !important;
+            }
+            .row-ada td.cell-hover,
+            td.cell-hover-ada {
+                background: rgba(var(--c-ada), 0.55) !important;
+                color: #fff !important;
+            }
+            .row-ampere td.cell-hover,
+            td.cell-hover-ampere {
+                background: rgba(var(--c-ampere), 0.55) !important;
+                color: #fff !important;
+            }
+            .row-turing td.cell-hover,
+            td.cell-hover-turing {
+                background: rgba(var(--c-turing), 0.55) !important;
+                color: #fff !important;
+            }
+            .row-volta td.cell-hover,
+            td.cell-hover-volta {
+                background: rgba(var(--c-volta), 0.55) !important;
+                color: #fff !important;
+            }
+
+            /* セル装飾クラス */
+            .arch {
+                font-weight: 700;
+                text-align: center;
+                vertical-align: middle;
+                padding: 8px 12px;
+                font-size: 0.95em;
+                letter-spacing: 0.01em;
+            }
+
+            .gpu {
+                font-weight: 600;
+                color: var(--aws-orange-light);
+            }
+            .inst {
+                font-family: "Consolas", "Monaco", monospace;
+                color: var(--c-inst);
+            }
+            .price {
+                color: var(--c-price);
+                font-weight: 500;
+            }
+            .cb {
+                color: var(--c-cb);
+            }
+            .cbo {
+                color: var(--c-warn);
+                font-size: 0.9em;
+            }
+            .efa {
+                color: var(--c-efa);
+            }
+            .pcie {
+                color: var(--c-pcie);
+            }
+            .est {
+                color: var(--c-est);
+                font-style: italic;
+            }
+            .ok {
+                color: var(--c-ok);
+                font-weight: 600;
+            }
+            .no {
+                color: var(--c-no);
+            }
+
+            .badge {
+                display: inline-block;
+                padding: 2px 6px;
+                border-radius: 4px;
+                font-size: 0.65em;
+                font-weight: 700;
+                background: linear-gradient(
+                    135deg,
+                    var(--aws-orange-dark),
+                    var(--aws-orange)
+                );
+                color: white;
+                margin-left: 4px;
+                text-transform: uppercase;
+                letter-spacing: 0.04em;
+            }
+
+            a {
+                color: inherit;
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+                opacity: 0.9;
+            }
+            .ec2-link {
+                color: var(--c-inst);
+            }
+            .ec2-link:hover {
+                color: #fff;
+            }
+
+            /* $/GPU(CB)列の幅を制限 */
+            td.cb,
+            th.cb-header {
+                max-width: 80px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+
+            /* Notes */
+            .notes {
+                margin-top: 24px;
+                padding: 20px 24px;
+                background: rgba(255, 255, 255, 0.04);
+                border: 1px solid rgba(255, 255, 255, 0.06);
+                border-radius: var(--border-radius);
+                font-size: 0.9em;
+                line-height: 1.7;
+            }
+
+            .notes h3 {
+                color: var(--aws-orange);
+                margin-bottom: 12px;
+                font-size: 1.05em;
+            }
+
+            .notes ul {
+                margin-left: 20px;
+            }
+            .notes li {
+                margin-bottom: 6px;
+                color: #c5cdd5;
+            }
+            .notes li strong {
+                color: #e8eaed;
+            }
+
+            /* スマホ対応 */
+            @media (max-width: 768px) {
+                body {
+                    padding: 12px;
                 }
+
+                h1 {
+                    font-size: 1.4em;
+                }
+
+                table {
+                    font-size: 0.85em;
+                }
+
+                th,
+                td {
+                    padding: 10px 6px;
+                }
+
+                .table-wrapper {
+                    -webkit-overflow-scrolling: touch;
+                }
+
+                .legend {
+                    flex-wrap: wrap;
+                    gap: 10px;
+                    padding: 12px;
+                }
+
+                .notes {
+                    padding: 14px;
+                    font-size: 0.9em;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h1>🚀 AWS EC2 GPU インスタンス リファレンスガイド</h1>
+            <p class="subtitle">
+                最終更新: 2026年1月31日 | 価格: 東京リージョン On-Demand (税抜)
+            </p>
+
+            <div class="legend">
+                <div class="legend-item">
+                    <div class="legend-color blackwell"></div>
+                    Blackwell (2024)
+                </div>
+                <div class="legend-item">
+                    <div class="legend-color hopper"></div>
+                    Hopper (2022)
+                </div>
+                <div class="legend-item">
+                    <div class="legend-color ada"></div>
+                    Ada Lovelace (2022)
+                </div>
+                <div class="legend-item">
+                    <div class="legend-color ampere"></div>
+                    Ampere (2020)
+                </div>
+                <div class="legend-item">
+                    <div class="legend-color turing"></div>
+                    Turing (2018)
+                </div>
+                <div class="legend-item">
+                    <div class="legend-color volta"></div>
+                    Volta (2017)
+                </div>
+            </div>
+
+            <div class="table-wrapper">
+                <table>
+                    <thead>
+                        <tr>
+                            <th colspan="4" class="group">インスタンス</th>
+                            <th colspan="4" class="group">GPU性能</th>
+                            <th colspan="2" class="group">接続</th>
+                            <th colspan="3" class="group">システム</th>
+                            <th colspan="3" class="group">価格</th>
+                            <th class="group"></th>
+                        </tr>
+                        <tr>
+                            <th>世代</th>
+                            <th>GPU</th>
+                            <th>EC2</th>
+                            <th>サイズ</th>
+                            <th>数</th>
+                            <th>VRAM</th>
+                            <th>FP16</th>
+                            <th>FP8</th>
+                            <th>
+                                <a
+                                    href="https://aws.amazon.com/hpc/efa/"
+                                    target="_blank"
+                                    title="Elastic Fabric Adapter"
+                                    >EFA</a
+                                >
+                            </th>
+                            <th>PCIe</th>
+                            <th>vCPU</th>
+                            <th>Mem</th>
+                            <th>NVMe</th>
+                            <th>
+                                <a
+                                    href="https://aws.amazon.com/ec2/pricing/on-demand/"
+                                    target="_blank"
+                                    title="EC2 On-Demand 料金"
+                                    >$/h</a
+                                >
+                            </th>
+                            <th>$/GPU</th>
+                            <th class="cb-header">
+                                <a
+                                    href="https://aws.amazon.com/ec2/capacityblocks/"
+                                    target="_blank"
+                                    title="Capacity Blocks for ML"
+                                    >$/GPU<br />(CB)</a
+                                >
+                            </th>
+                            <th>東京</th>
+                        </tr>
+                    </thead>
+                    <tbody id="gpu-table-body"></tbody>
+                </table>
+            </div>
+
+            <div class="notes">
+                <h3>📝 Notes</h3>
+                <ul>
+                    <li>
+                        <strong>価格:</strong>
+                        2025年6月の値下げ反映済み。東京リージョン On-Demand 価格
+                        (USD)。CB = Capacity Blocks。TBD = 価格未発表。
+                    </li>
+                    <li>
+                        <strong>G7e (NEW):</strong> NVIDIA RTX PRO 6000
+                        Blackwell Server Edition
+                        GPU搭載。G6eの2.3倍の推論性能、2倍のVRAM
+                        (96GB/GPU)。48xlargeのみEFA対応。現在
+                        us-east-1/us-east-2 のみ。
+                    </li>
+                    <li>
+                        <strong>P5en vs P5e vs P5:</strong>
+                        <ul>
+                            <li>
+                                <strong>P5en:</strong> H200 + EFAv3 + PCIe Gen5
+                                → 最新・最高性能、On-Demand利用可
+                            </li>
+                            <li>
+                                <strong>P5e:</strong> H200 + EFAv2 + PCIe Gen4 →
+                                CB専用、P5enより低コスト
+                            </li>
+                            <li>
+                                <strong>P5:</strong> H100 + EFAv2 + PCIe Gen4 →
+                                VRAM 640GB、最もコスパ良好
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <strong>EFA:</strong> Elastic Fabric
+                        Adapter。マルチノード分散学習に必須。v4 > v3 > v2 > v1
+                        の順で高性能。
+                    </li>
+                    <li>
+                        <strong>PCIe:</strong>
+                        Gen5はGen4の約2倍の帯域幅。CPU-GPU間のデータ転送速度に影響。
+                    </li>
+                    <li>
+                        <strong>推奨:</strong>
+                        <ul>
+                            <li>
+                                大規模LLM学習: P6-B200/B300 (Blackwell) or P5en
+                                (H200)
+                            </li>
+                            <li>中規模学習/推論: P5 (H100) or G6e (L40S)</li>
+                            <li>
+                                GenAI推論/グラフィックス: G7e (RTX PRO 6000) -
+                                70Bモデルを1GPUで実行可能
+                            </li>
+                            <li>
+                                推論/ファインチューニング: G6 (L4) or G5 (A10G)
+                            </li>
+                            <li>
+                                コスト重視の推論: G4dn (T4) or G5g
+                                (T4G/Graviton)
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <strong>FP16/FP8:</strong>
+                        TFLOPS値（Sparsity有効時）。FP8は主にTransformer推論で使用。T4/V100はFP8非対応。<span
+                            class="est"
+                            >*付きは予想値</span
+                        >（G6f: GPU分割比率から算出、G7e:
+                        AWSブログ記事からの情報でNVIDIA公式未確認）。
+                    </li>
+                </ul>
+                <h3 style="margin-top: 15px">🔗 公式リファレンス</h3>
+                <ul>
+                    <li>
+                        <a
+                            href="https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing"
+                            target="_blank"
+                            >EC2 Accelerated Computing インスタンス一覧</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://aws.amazon.com/ec2/pricing/on-demand/"
+                            target="_blank"
+                            >EC2 On-Demand 料金</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://aws.amazon.com/ec2/capacityblocks/"
+                            target="_blank"
+                            >Capacity Blocks for ML</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://aws.amazon.com/hpc/efa/"
+                            target="_blank"
+                            >Elastic Fabric Adapter (EFA)</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html"
+                            target="_blank"
+                            >EC2 ユーザーガイド -
+                            アクセラレーテッドコンピューティング</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://aws.amazon.com/blogs/aws/category/compute/amazon-ec2/"
+                            target="_blank"
+                            >AWS Blog - EC2 カテゴリ（最新情報）</a
+                        >
+                    </li>
+                </ul>
+                <h3 style="margin-top: 15px">⚠️ 免責事項</h3>
+                <p style="color: #fdcb6e; font-size: 0.9em; line-height: 1.6">
+                    本ページの情報は参考用であり、正確性を保証するものではありません。価格・仕様・リージョン対応状況は予告なく変更される場合があります。
+                    最新かつ正確な情報については、必ず<a
+                        href="https://aws.amazon.com/ec2/instance-types/"
+                        target="_blank"
+                        style="color: #74b9ff"
+                        >AWS公式ドキュメント</a
+                    >をご確認ください。
+                    本ページの情報に基づく判断・行動によって生じた損害について、作成者は一切の責任を負いません。
+                </p>
+            </div>
+        </div>
+
+        <script>
+            // EC2タイプからAWS公式ページURLを生成
+            const EC2_LINKS = {
+                "P6-B300": "https://aws.amazon.com/ec2/instance-types/p6/",
+                "P6-B200": "https://aws.amazon.com/ec2/instance-types/p6/",
+                G7e: "https://aws.amazon.com/ec2/instance-types/g7e/",
+                P5en: "https://aws.amazon.com/ec2/instance-types/p5/",
+                P5e: "https://aws.amazon.com/ec2/instance-types/p5/",
+                P5: "https://aws.amazon.com/ec2/instance-types/p5/",
+                G6e: "https://aws.amazon.com/ec2/instance-types/g6e/",
+                G6: "https://aws.amazon.com/ec2/instance-types/g6/",
+                G6f: "https://aws.amazon.com/ec2/instance-types/g6/",
+                P4d: "https://aws.amazon.com/ec2/instance-types/p4/",
+                P4de: "https://aws.amazon.com/ec2/instance-types/p4/",
+                G5: "https://aws.amazon.com/ec2/instance-types/g5/",
+                G4dn: "https://aws.amazon.com/ec2/instance-types/g4/",
+                G5g: "https://aws.amazon.com/ec2/instance-types/g5g/",
+                P3: "https://aws.amazon.com/ec2/instance-types/p3/",
+                P3dn: "https://aws.amazon.com/ec2/instance-types/p3/",
+            };
+
+            // GPU インスタンスデータ
+            // count: GPU数、vramPerGpu: 1GPU当たりのVRAM、fp16PerGpu/fp8PerGpu: 1GPU当たりの性能
+            const GPU_DATA = [
+                // Blackwell
+                {
+                    gen: "blackwell",
+                    genRows: 8,
+                    gpu: "B300",
+                    gpuNew: true,
+                    ec2: "P6-B300",
+                    size: "p6-b300.48xlarge",
+                    count: 8,
+                    vramPerGpu: 288,
+                    fp16PerGpu: 2250,
+                    fp8PerGpu: 4500,
+                    efa: "v4 3200G",
+                    pcie: "Gen5",
+                    vcpu: 192,
+                    mem: "4TB",
+                    nvme: "30TB",
+                    price: null,
+                    priceGpu: null,
+                    priceCb: "$11.70",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    gpu: "B200",
+                    ec2: "P6-B200",
+                    size: "p6-b200.48xlarge",
+                    count: 8,
+                    vramPerGpu: 180,
+                    fp16PerGpu: 2250,
+                    fp8PerGpu: 4500,
+                    efa: "v4 3200G",
+                    pcie: "Gen5",
+                    vcpu: 192,
+                    mem: "2TB",
+                    nvme: "30TB",
+                    price: null,
+                    priceGpu: null,
+                    priceCb: "$9.36",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    gpu: "RTX PRO",
+                    gpuNew: true,
+                    gpuRows: 6,
+                    ec2: "G7e",
+                    ec2Rows: 6,
+                    size: "g7e.2xlarge",
+                    count: 1,
+                    vramPerGpu: 96,
+                    fp16PerGpu: 240,
+                    fp8PerGpu: 480,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen5",
+                    vcpu: 8,
+                    mem: "64GB",
+                    nvme: "1.9TB",
+                    price: "$3.36",
+                    priceGpu: "$3.36",
+                    priceCb: "-",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    size: "g7e.4xlarge",
+                    count: 1,
+                    vramPerGpu: 96,
+                    fp16PerGpu: 240,
+                    fp8PerGpu: 480,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen5",
+                    vcpu: 16,
+                    mem: "128GB",
+                    nvme: "1.9TB",
+                    price: "$4.00",
+                    priceGpu: "$4.00",
+                    priceCb: "-",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    size: "g7e.8xlarge",
+                    count: 1,
+                    vramPerGpu: 96,
+                    fp16PerGpu: 240,
+                    fp8PerGpu: 480,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen5",
+                    vcpu: 32,
+                    mem: "256GB",
+                    nvme: "1.9TB",
+                    price: "$5.27",
+                    priceGpu: "$5.27",
+                    priceCb: "-",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    size: "g7e.12xlarge",
+                    count: 2,
+                    vramPerGpu: 96,
+                    fp16PerGpu: 240,
+                    fp8PerGpu: 480,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen5",
+                    vcpu: 48,
+                    mem: "512GB",
+                    nvme: "3.8TB",
+                    price: "$8.29",
+                    priceGpu: "$4.14",
+                    priceCb: "-",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    size: "g7e.24xlarge",
+                    count: 4,
+                    vramPerGpu: 96,
+                    fp16PerGpu: 240,
+                    fp8PerGpu: 480,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen5",
+                    vcpu: 96,
+                    mem: "1TB",
+                    nvme: "7.6TB",
+                    price: "$16.57",
+                    priceGpu: "$4.14",
+                    priceCb: "-",
+                    tokyo: false,
+                },
+                {
+                    gen: "blackwell",
+                    size: "g7e.48xlarge",
+                    count: 8,
+                    vramPerGpu: 96,
+                    fp16PerGpu: 240,
+                    fp8PerGpu: 480,
+                    est: true,
+                    efa: "1600G",
+                    pcie: "Gen5",
+                    vcpu: 192,
+                    mem: "2TB",
+                    nvme: "15.2TB",
+                    price: "$33.14",
+                    priceGpu: "$4.14",
+                    priceCb: "-",
+                    tokyo: false,
+                },
+                // Hopper
+                {
+                    gen: "hopper",
+                    genRows: 4,
+                    gpu: "H200",
+                    ec2: "P5en",
+                    size: "p5en.48xlarge",
+                    count: 8,
+                    vramPerGpu: 141,
+                    fp16PerGpu: 1979,
+                    fp8PerGpu: 3958,
+                    efa: "v3 3200G",
+                    pcie: "Gen5",
+                    vcpu: 192,
+                    mem: "2TB",
+                    nvme: "30TB",
+                    price: "$63.30",
+                    priceGpu: "$7.91",
+                    priceCb: "$5.20",
+                    tokyo: true,
+                },
+                {
+                    gen: "hopper",
+                    gpu: "H200",
+                    ec2: "P5e",
+                    size: "p5e.48xlarge",
+                    count: 8,
+                    vramPerGpu: 141,
+                    fp16PerGpu: 1979,
+                    fp8PerGpu: 3958,
+                    efa: "v2 3200G",
+                    pcie: "Gen4",
+                    vcpu: 192,
+                    mem: "2TB",
+                    nvme: "30TB",
+                    price: null,
+                    priceGpu: null,
+                    priceCb: "$4.98",
+                    tokyo: true,
+                },
+                {
+                    gen: "hopper",
+                    gpu: "H100",
+                    gpuRows: 2,
+                    ec2: "P5",
+                    ec2Rows: 2,
+                    size: "p5.48xlarge",
+                    count: 8,
+                    vramPerGpu: 80,
+                    fp16PerGpu: 1979,
+                    fp8PerGpu: 3958,
+                    efa: "v2 3200G",
+                    pcie: "Gen4",
+                    vcpu: 192,
+                    mem: "2TB",
+                    nvme: "30TB",
+                    price: "$30.27",
+                    priceGpu: "$3.78",
+                    priceCb: "$3.93",
+                    tokyo: true,
+                },
+                {
+                    gen: "hopper",
+                    size: "p5.4xlarge",
+                    count: 1,
+                    vramPerGpu: 80,
+                    fp16PerGpu: 1979,
+                    fp8PerGpu: 3958,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 24,
+                    mem: "256GB",
+                    nvme: "3.8TB",
+                    price: "$3.78",
+                    priceGpu: "$3.78",
+                    priceCb: "$3.78",
+                    tokyo: true,
+                },
+
+                // Ada Lovelace - G6e L40S
+                {
+                    gen: "ada",
+                    genRows: 11,
+                    gpu: "L40S",
+                    gpuRows: 4,
+                    ec2: "G6e",
+                    ec2Rows: 4,
+                    size: "g6e.xlarge",
+                    count: 1,
+                    vramPerGpu: 48,
+                    fp16PerGpu: 733,
+                    fp8PerGpu: 1466,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 4,
+                    mem: "32GB",
+                    nvme: "-",
+                    price: "$1.86",
+                    priceGpu: "$1.86",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6e.4xlarge",
+                    count: 1,
+                    vramPerGpu: 48,
+                    fp16PerGpu: 733,
+                    fp8PerGpu: 1466,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 16,
+                    mem: "128GB",
+                    nvme: "-",
+                    price: "$3.00",
+                    priceGpu: "$3.00",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6e.12xlarge",
+                    count: 4,
+                    vramPerGpu: 48,
+                    fp16PerGpu: 733,
+                    fp8PerGpu: 1466,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 48,
+                    mem: "384GB",
+                    nvme: "-",
+                    price: "$10.49",
+                    priceGpu: "$2.62",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6e.48xlarge",
+                    count: 8,
+                    vramPerGpu: 48,
+                    fp16PerGpu: 733,
+                    fp8PerGpu: 1466,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 192,
+                    mem: "1.5TB",
+                    nvme: "-",
+                    price: "$30.13",
+                    priceGpu: "$3.77",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                // Ada - G6 L4
+                {
+                    gen: "ada",
+                    gpu: "L4",
+                    gpuRows: 4,
+                    ec2: "G6",
+                    ec2Rows: 4,
+                    size: "g6.xlarge",
+                    count: 1,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 4,
+                    mem: "16GB",
+                    nvme: "-",
+                    price: "$0.80",
+                    priceGpu: "$0.80",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6.4xlarge",
+                    count: 1,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 16,
+                    mem: "64GB",
+                    nvme: "-",
+                    price: "$1.32",
+                    priceGpu: "$1.32",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6.12xlarge",
+                    count: 4,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 48,
+                    mem: "192GB",
+                    nvme: "-",
+                    price: "$4.60",
+                    priceGpu: "$1.15",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6.48xlarge",
+                    count: 8,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 192,
+                    mem: "768GB",
+                    nvme: "-",
+                    price: "$13.35",
+                    priceGpu: "$1.67",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                // Ada - G6f L4
+                {
+                    gen: "ada",
+                    gpu: "L4",
+                    gpuRows: 3,
+                    ec2: "G6f",
+                    ec2Rows: 3,
+                    size: "g6f.large",
+                    count: "1/8",
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 2,
+                    mem: "6GB",
+                    nvme: "-",
+                    price: "$0.20",
+                    priceGpu: "$1.60",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6f.xlarge",
+                    count: "1/8",
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 4,
+                    mem: "16GB",
+                    nvme: "-",
+                    price: "$0.24",
+                    priceGpu: "$1.92",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ada",
+                    size: "g6f.4xlarge",
+                    count: "1/2",
+                    vramPerGpu: 24,
+                    fp16PerGpu: 242,
+                    fp8PerGpu: 485,
+                    est: true,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 16,
+                    mem: "64GB",
+                    nvme: "-",
+                    price: "$0.95",
+                    priceGpu: "$1.90",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                // Ampere
+                {
+                    gen: "ampere",
+                    genRows: 9,
+                    gpu: "A100 40GB",
+                    ec2: "P4d",
+                    size: "p4d.24xlarge",
+                    count: 8,
+                    vramPerGpu: 40,
+                    fp16PerGpu: 312,
+                    fp8PerGpu: null,
+                    efa: "v1 400G",
+                    pcie: "Gen4",
+                    vcpu: 96,
+                    mem: "1.1TB",
+                    nvme: "8TB",
+                    price: "$14.71",
+                    priceGpu: "$1.84",
+                    priceCb: "$1.48",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    gpu: "A100 80GB",
+                    ec2: "P4de",
+                    size: "p4de.24xlarge",
+                    count: 8,
+                    vramPerGpu: 80,
+                    fp16PerGpu: 312,
+                    fp8PerGpu: null,
+                    efa: "v1 400G",
+                    pcie: "Gen4",
+                    vcpu: 96,
+                    mem: "1.1TB",
+                    nvme: "8TB",
+                    price: "$18.40",
+                    priceGpu: "$2.30",
+                    priceCb: "$1.85",
+                    tokyo: false,
+                },
+                {
+                    gen: "ampere",
+                    gpu: "A10G",
+                    gpuRows: 7,
+                    ec2: "G5",
+                    ec2Rows: 7,
+                    size: "g5.xlarge",
+                    count: 1,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 4,
+                    mem: "16GB",
+                    nvme: "125GB",
+                    price: "$1.01",
+                    priceGpu: "$1.01",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    size: "g5.2xlarge",
+                    count: 1,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 8,
+                    mem: "32GB",
+                    nvme: "450GB",
+                    price: "$1.21",
+                    priceGpu: "$1.21",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    size: "g5.4xlarge",
+                    count: 1,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 16,
+                    mem: "64GB",
+                    nvme: "600GB",
+                    price: "$1.62",
+                    priceGpu: "$1.62",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    size: "g5.8xlarge",
+                    count: 1,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 32,
+                    mem: "128GB",
+                    nvme: "900GB",
+                    price: "$2.45",
+                    priceGpu: "$2.45",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    size: "g5.12xlarge",
+                    count: 4,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 48,
+                    mem: "192GB",
+                    nvme: "3.8TB",
+                    price: "$5.67",
+                    priceGpu: "$1.42",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    size: "g5.24xlarge",
+                    count: 4,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 96,
+                    mem: "384GB",
+                    nvme: "3.8TB",
+                    price: "$8.14",
+                    priceGpu: "$2.04",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "ampere",
+                    size: "g5.48xlarge",
+                    count: 8,
+                    vramPerGpu: 24,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen4",
+                    vcpu: 192,
+                    mem: "768GB",
+                    nvme: "7.6TB",
+                    price: "$16.29",
+                    priceGpu: "$2.04",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+
+                // Turing - G4dn T4
+                {
+                    gen: "turing",
+                    genRows: 11,
+                    gpu: "T4",
+                    gpuRows: 6,
+                    ec2: "G4dn",
+                    ec2Rows: 6,
+                    size: "g4dn.xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 4,
+                    mem: "16GB",
+                    nvme: "125GB",
+                    price: "$0.53",
+                    priceGpu: "$0.53",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g4dn.2xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 8,
+                    mem: "32GB",
+                    nvme: "225GB",
+                    price: "$0.75",
+                    priceGpu: "$0.75",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g4dn.4xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 16,
+                    mem: "64GB",
+                    nvme: "225GB",
+                    price: "$1.20",
+                    priceGpu: "$1.20",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g4dn.8xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 32,
+                    mem: "128GB",
+                    nvme: "900GB",
+                    price: "$2.18",
+                    priceGpu: "$2.18",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g4dn.12xlarge",
+                    count: 4,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 48,
+                    mem: "192GB",
+                    nvme: "900GB",
+                    price: "$3.91",
+                    priceGpu: "$0.98",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g4dn.metal",
+                    count: 8,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 96,
+                    mem: "384GB",
+                    nvme: "1.8TB",
+                    price: "$7.82",
+                    priceGpu: "$0.98",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                // Turing - G5g T4G
+                {
+                    gen: "turing",
+                    gpu: "T4G",
+                    gpuRows: 5,
+                    ec2: "G5g",
+                    ec2Rows: 5,
+                    size: "g5g.xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 4,
+                    mem: "8GB",
+                    nvme: "-",
+                    price: "$0.42",
+                    priceGpu: "$0.42",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g5g.2xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 8,
+                    mem: "16GB",
+                    nvme: "-",
+                    price: "$0.56",
+                    priceGpu: "$0.56",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g5g.4xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 16,
+                    mem: "32GB",
+                    nvme: "-",
+                    price: "$0.83",
+                    priceGpu: "$0.83",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g5g.8xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 32,
+                    mem: "64GB",
+                    nvme: "-",
+                    price: "$1.37",
+                    priceGpu: "$1.37",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "turing",
+                    size: "g5g.16xlarge",
+                    count: 2,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 65,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 64,
+                    mem: "128GB",
+                    nvme: "-",
+                    price: "$2.74",
+                    priceGpu: "$1.37",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                // Volta
+                {
+                    gen: "volta",
+                    genRows: 4,
+                    gpu: "V100",
+                    gpuRows: 4,
+                    ec2: "P3",
+                    ec2Rows: 3,
+                    size: "p3.2xlarge",
+                    count: 1,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 8,
+                    mem: "61GB",
+                    nvme: "-",
+                    price: "$3.06",
+                    priceGpu: "$3.06",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "volta",
+                    size: "p3.8xlarge",
+                    count: 4,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 32,
+                    mem: "244GB",
+                    nvme: "-",
+                    price: "$12.24",
+                    priceGpu: "$3.06",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "volta",
+                    size: "p3.16xlarge",
+                    count: 8,
+                    vramPerGpu: 16,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "-",
+                    pcie: "Gen3",
+                    vcpu: 64,
+                    mem: "488GB",
+                    nvme: "-",
+                    price: "$24.48",
+                    priceGpu: "$3.06",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+                {
+                    gen: "volta",
+                    ec2: "P3dn",
+                    size: "p3dn.24xlarge",
+                    count: 8,
+                    vramPerGpu: 32,
+                    fp16PerGpu: 125,
+                    fp8PerGpu: null,
+                    efa: "100G",
+                    pcie: "Gen3",
+                    vcpu: 96,
+                    mem: "768GB",
+                    nvme: "1.8TB",
+                    price: "$31.21",
+                    priceGpu: "$3.90",
+                    priceCb: "-",
+                    tokyo: true,
+                },
+            ];
+
+            const GEN_LABELS = {
+                blackwell: "Blackwell",
+                hopper: "Hopper",
+                ada: "Ada",
+                ampere: "Ampere",
+                turing: "Turing",
+                volta: "Volta",
+            };
+
+            // 数値のフォーマット関数（カンマ区切り）
+            function formatNumber(num) {
+                return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            }
+
+            // VRAM表示の生成（1GPU当たり + 合計）
+            function formatVram(vramPerGpu, count) {
+                // G6fの分数表記の場合
+                if (typeof count === "string" && count.includes("/")) {
+                    const fraction = eval(count); // 1/8 → 0.125
+                    const totalVram = vramPerGpu * fraction;
+                    return `${totalVram}GB`;
+                }
+
+                const numCount =
+                    typeof count === "number" ? count : parseInt(count);
+
+                if (numCount === 1) {
+                    return `${vramPerGpu}GB`;
+                }
+
+                const totalGb = vramPerGpu * numCount;
+
+                // 1TB以上の場合はTB表記
+                if (totalGb >= 1000) {
+                    const totalTb = (totalGb / 1000).toFixed(1);
+                    return `${vramPerGpu}GB<br><small>(${totalTb}TB)</small>`;
+                }
+
+                return `${vramPerGpu}GB<br><small>(${totalGb}GB)</small>`;
+            }
+
+            // 性能表示の生成（1GPU当たり + 合計）
+            function formatPerf(perfPerGpu, count, est = false) {
+                if (perfPerGpu === null) return "-";
+
+                // G6fの分数表記の場合
+                if (typeof count === "string" && count.includes("/")) {
+                    const fraction = eval(count);
+                    const totalPerf = Math.round(perfPerGpu * fraction);
+                    return `${est ? totalPerf + "*" : totalPerf}`;
+                }
+
+                const numCount =
+                    typeof count === "number" ? count : parseInt(count);
+
+                if (numCount === 1) {
+                    return `${est ? formatNumber(perfPerGpu) + "*" : formatNumber(perfPerGpu)}`;
+                }
+
+                const totalPerf = perfPerGpu * numCount;
+                return `${formatNumber(perfPerGpu)}<br><small>(${formatNumber(totalPerf)})</small>${est ? "*" : ""}`;
+            }
+
+            // テーブル生成
+            function renderTable() {
+                const tbody = document.getElementById("gpu-table-body");
+                let html = "";
+
+                GPU_DATA.forEach((row, i) => {
+                    const rowClass = `row-${row.gen}`;
+                    html += `<tr class="${rowClass}">`;
+
+                    // 世代セル
+                    if (row.genRows) {
+                        html += `<td class="arch" rowspan="${row.genRows}">${GEN_LABELS[row.gen]}</td>`;
+                    }
+                    // GPUセル
+                    if (row.gpu) {
+                        const badge = row.gpuNew
+                            ? '<span class="badge">NEW</span>'
+                            : "";
+                        const rs = row.gpuRows
+                            ? ` rowspan="${row.gpuRows}"`
+                            : "";
+                        html += `<td class="gpu"${rs}>${row.gpu}${badge}</td>`;
+                    }
+                    // EC2セル（リンク付き）
+                    if (row.ec2) {
+                        const rs = row.ec2Rows
+                            ? ` rowspan="${row.ec2Rows}"`
+                            : "";
+                        const link = EC2_LINKS[row.ec2] || "#";
+                        html += `<td${rs}><a href="${link}" target="_blank" class="ec2-link" title="${row.ec2} インスタンス詳細">${row.ec2}</a></td>`;
+                    }
+                    // サイズ
+                    html += `<td class="inst">${row.size}</td>`;
+                    // GPU数
+                    html += `<td>${row.count}</td>`;
+                    // VRAM（1GPU当たり + 合計）
+                    html += `<td>${formatVram(row.vramPerGpu, row.count)}</td>`;
+                    // FP16（1GPU当たり + 合計）
+                    const estClass = row.est ? ' class="est"' : "";
+                    html += `<td${estClass}>${formatPerf(row.fp16PerGpu, row.count, row.est)}</td>`;
+                    // FP8（1GPU当たり + 合計）
+                    html += `<td${estClass}>${formatPerf(row.fp8PerGpu, row.count, row.est)}</td>`;
+                    // EFA, PCIe
+                    html += `<td class="efa">${row.efa}</td><td class="pcie">${row.pcie}</td>`;
+                    // vCPU, Mem, NVMe
+                    html += `<td>${row.vcpu}</td><td>${row.mem}</td><td>${row.nvme}</td>`;
+                    // 価格
+                    const priceClass =
+                        row.price && row.price !== "TBD" ? "price" : "cbo";
+                    html += `<td class="${priceClass}">${row.price || "CB専用"}</td>`;
+                    html += `<td class="${priceClass}">${row.priceGpu || "-"}</td>`;
+                    html += `<td class="cb">${row.priceCb}</td>`;
+                    // 東京
+                    html += `<td class="${row.tokyo ? "ok" : "no"}">${row.tokyo ? "◯" : "✕"}</td>`;
+                    html += "</tr>";
+                });
+
+                tbody.innerHTML = html;
+            }
+
+            // ホバーエフェクト
+            function setupHover() {
+                const rows = document.querySelectorAll("tbody tr");
+                const spanningCells = [];
+
+                // rowspanセル収集
+                rows.forEach((row, i) => {
+                    const gen = row.className.replace("row-", "");
+                    row.querySelectorAll("td[rowspan]").forEach((cell) => {
+                        spanningCells.push({
+                            cell,
+                            startRow: i,
+                            endRow:
+                                i + parseInt(cell.getAttribute("rowspan")) - 1,
+                            gen,
+                        });
+                    });
+                });
+
+                rows.forEach((row, rowIndex) => {
+                    const gen = row.className.replace("row-", "");
+                    const hoverClass = `cell-hover-${gen}`;
+
+                    row.addEventListener("mouseenter", () => {
+                        row.querySelectorAll("td").forEach((td) =>
+                            td.classList.add("cell-hover"),
+                        );
+                        spanningCells.forEach((sc) => {
+                            if (
+                                rowIndex >= sc.startRow &&
+                                rowIndex <= sc.endRow
+                            ) {
+                                sc.cell.classList.add(`cell-hover-${sc.gen}`);
+                            }
+                        });
+                    });
+
+                    row.addEventListener("mouseleave", () => {
+                        row.querySelectorAll("td").forEach((td) =>
+                            td.classList.remove("cell-hover"),
+                        );
+                        spanningCells.forEach((sc) =>
+                            sc.cell.classList.remove(`cell-hover-${sc.gen}`),
+                        );
+                    });
+                });
+            }
+
+            document.addEventListener("DOMContentLoaded", () => {
+                renderTable();
+                setupHover();
             });
-        });
-
-        row.addEventListener('mouseleave', () => {
-            row.querySelectorAll('td').forEach(td => td.classList.remove('cell-hover'));
-            spanningCells.forEach(sc => sc.cell.classList.remove(`cell-hover-${sc.gen}`));
-        });
-    });
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    renderTable();
-    setupHover();
-});
-</script>
-</body>
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
## 概要

G7eインスタンスの価格を「TBD」から実際のOn-Demand価格に更新しました。

## 変更内容

AWS Price List Bulk API (us-east-1リージョン) から取得した最新のOn-Demand価格:

| インスタンス | On-Demand価格 | GPU単価 |
|---|---|---|
| g7e.2xlarge (1 GPU) | $3.36/hr | $3.36/hr |
| g7e.4xlarge (1 GPU) | $4.00/hr | $4.00/hr |
| g7e.8xlarge (1 GPU) | $5.27/hr | $5.27/hr |
| g7e.12xlarge (2 GPU) | $8.29/hr | $4.14/hr |
| g7e.24xlarge (4 GPU) | $16.57/hr | $4.14/hr |
| g7e.48xlarge (8 GPU) | $33.14/hr | $4.14/hr |

## 補足

- **CB価格**: G7eはCapacity Blocksの価格データに存在しないため「-」のまま
- **東京リージョン**: G7eは東京リージョン (ap-northeast-1) では未提供のため `tokyo: false` のまま
- **データソース**: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-1/index.json (2026-02-06版)

Closes #17