### PR TITLE
fix: GitHub ActionsのClaudeにインターネットアクセス権限を付与

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,26 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'COLLABORATOR')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'COLLABORATOR')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,8 +58,7 @@ jobs:
                 "allow": [
                   "WebFetch",
                   "WebSearch",
-                  "Bash(curl:*)",
-                  "Bash(python3:*)"
+                  "Bash(curl:*)"
                 ]
               }
             }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,17 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model opus"
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "WebFetch",
+                  "WebSearch",
+                  "Bash(curl:*)",
+                  "Bash(python3:*)"
+                ]
+              }
+            }
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## 概要

GitHub Actions上のClaudeがインターネットにアクセスできない問題を修正します。

## 背景

Issue #17でClaudeがAWS価格データを取得しようとした際、WebFetch・WebSearch・Bash(curl/wget/python3)がすべてブロックされて失敗しました。これは`claude-code-action`のデフォルト設定ではこれらのツールが許可されていないためです。

## 変更内容

`.github/workflows/claude.yml`に`settings`パラメータを追加し、以下のツールを許可:

| ツール | 用途 |
|---|---|
| `WebFetch` | WebURLからのコンテンツ取得（AWS価格API等） |
| `WebSearch` | Web検索による情報収集 |
| `Bash(curl:*)` | curlによるHTTPリクエスト |
| `Bash(python3:*)` | Pythonスクリプト実行（大規模JSONの解析等） |

## 検証方法

マージ後、Issueで`@claude`にメンションして価格取得タスクを依頼し、WebFetch/Bash(curl)が正常に動作することを確認する。