### PR TITLE
feat: 言語選択をプルダウンに変更

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,11 @@
     <div class="container">
       <div class="site-header">
         <div class="header-controls">
-          <button id="lang-toggle" class="header-btn" type="button">English</button>
+          <select id="lang-select" class="header-btn">
+            <option value="ja">日本語</option>
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+          </select>
           <button id="theme-toggle" class="header-btn" type="button">☀️</button>
         </div>
         <h1 data-i18n="header.title">🚀 AWS EC2 GPU インスタンス リファレンスガイド</h1>

--- a/src/scripts/i18n.js
+++ b/src/scripts/i18n.js
@@ -4,9 +4,6 @@ import { ko } from "../i18n/ko.js";
 
 const STORAGE_KEY = "gpu-ref-lang";
 const dictionaries = { ja, en, ko };
-const LANG_ORDER = ["ja", "en", "ko"];
-const LANG_LABELS = { ja: "日本語", en: "English", ko: "한국어" };
-
 let currentLang = "ja";
 
 function detectLanguage() {
@@ -55,22 +52,13 @@ export function initI18n() {
   applyTranslations();
 }
 
-function nextLangLabel() {
-  const idx = LANG_ORDER.indexOf(currentLang);
-  const nextLang = LANG_ORDER[(idx + 1) % LANG_ORDER.length];
-  return LANG_LABELS[nextLang];
-}
-
 export function setupLangToggle() {
-  const btn = document.getElementById("lang-toggle");
-  if (!btn) return;
-  btn.addEventListener("click", () => {
-    const idx = LANG_ORDER.indexOf(currentLang);
-    const nextLang = LANG_ORDER[(idx + 1) % LANG_ORDER.length];
-    setLang(nextLang);
-    btn.textContent = nextLangLabel();
+  const select = document.getElementById("lang-select");
+  if (!select) return;
+  select.value = currentLang;
+  select.addEventListener("change", () => {
+    setLang(select.value);
   });
-  btn.textContent = nextLangLabel();
 }
 
 export { detectLanguage };

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -29,6 +29,11 @@
   color: #e8eaed;
 }
 
+#lang-select {
+  appearance: auto;
+  cursor: pointer;
+}
+
 #theme-toggle {
   font-size: 1.1em;
   padding: 6px 10px;


### PR DESCRIPTION
## Summary
- 言語選択をボタンのサイクル方式からプルダウン（select要素）に変更
- 不要になったLANG_ORDER, LANG_LABELS, nextLangLabel()を削除

Closes #23

Generated with [Claude Code](https://claude.ai/code)