### PR TITLE
feat: On-Demand単価調整を$/GPU/hに変更

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -50,7 +50,7 @@ export const en = {
     cbMonthly: "Capacity Blocks Monthly",
     cbYearly: "Capacity Blocks Yearly",
     cbOnly: "CB Only",
-    odUnitPriceLabel: "On-Demand Unit Price ($/h)",
+    odUnitPriceLabel: "On-Demand Unit Price ($/GPU/h)",
     cbUnitPriceLabel: "CB Unit Price ($/GPU/h)",
     resetPrice: "Reset to default",
     defaultPrice: "Default",

--- a/src/i18n/ja.js
+++ b/src/i18n/ja.js
@@ -50,7 +50,7 @@ export const ja = {
     cbMonthly: "Capacity Blocks 月額",
     cbYearly: "Capacity Blocks 年額",
     cbOnly: "CB専用",
-    odUnitPriceLabel: "On-Demand 単価 ($/h)",
+    odUnitPriceLabel: "On-Demand 単価 ($/GPU/h)",
     cbUnitPriceLabel: "CB 単価 ($/GPU/h)",
     resetPrice: "デフォルトに戻す",
     defaultPrice: "デフォルト",

--- a/src/i18n/ko.js
+++ b/src/i18n/ko.js
@@ -50,7 +50,7 @@ export const ko = {
     cbMonthly: "Capacity Blocks 월간 비용",
     cbYearly: "Capacity Blocks 연간 비용",
     cbOnly: "CB 전용",
-    odUnitPriceLabel: "On-Demand 단가 ($/h)",
+    odUnitPriceLabel: "On-Demand 단가 ($/GPU/h)",
     cbUnitPriceLabel: "CB 단가 ($/GPU/h)",
     resetPrice: "기본값으로 복원",
     defaultPrice: "기본값",

--- a/src/index.html
+++ b/src/index.html
@@ -146,7 +146,7 @@
             <input type="number" id="calc-exchange-rate" value="150" min="1" step="0.01" />
           </div>
           <div class="calculator-input unit-price-field">
-            <label for="calc-od-unit-price" data-i18n="calculator.odUnitPriceLabel">On-Demand 単価 ($/h)</label>
+            <label for="calc-od-unit-price" data-i18n="calculator.odUnitPriceLabel">On-Demand 単価 ($/GPU/h)</label>
             <div class="unit-price-input-wrapper">
               <span class="unit-price-prefix">$</span>
               <input type="number" id="calc-od-unit-price" step="0.01" min="0" placeholder="-" />

--- a/src/scripts/calculator.js
+++ b/src/scripts/calculator.js
@@ -59,6 +59,7 @@ function getUniqueInstances() {
       size: row.size,
       label: `${row.size} (${gpuName} x${row.count})`,
       price: row.price,
+      priceGpu: row.priceGpu,
       priceCb: row.priceCb,
       count: row.count,
       cbOnly: isCbOnly(row),
@@ -70,12 +71,12 @@ function updateDefaultPriceDisplay(row) {
   const odDefault = document.getElementById("calc-od-default-price");
   const cbDefault = document.getElementById("calc-cb-default-price");
 
-  const odPrice = parsePrice(row.price);
+  const odGpuPrice = parsePrice(row.priceGpu);
   const cbPrice = parsePrice(row.priceCb);
 
   if (odDefault) {
-    odDefault.textContent = odPrice != null
-      ? `${t("calculator.defaultPrice")}: $${odPrice.toFixed(2)}`
+    odDefault.textContent = odGpuPrice != null
+      ? `${t("calculator.defaultPrice")}: $${odGpuPrice.toFixed(2)}`
       : `${t("calculator.defaultPrice")}: -`;
   }
   if (cbDefault) {
@@ -90,11 +91,11 @@ function updateUnitPrices(row) {
   const cbInput = document.getElementById("calc-cb-unit-price");
   if (!odInput || !cbInput) return;
 
-  const odPrice = parsePrice(row.price);
+  const odGpuPrice = parsePrice(row.priceGpu);
   const cbPrice = parsePrice(row.priceCb);
 
   if (!odUserEdited) {
-    odInput.value = odPrice != null ? odPrice.toFixed(2) : "";
+    odInput.value = odGpuPrice != null ? odGpuPrice.toFixed(2) : "";
     odInput.classList.remove("user-edited");
   }
   if (!cbUserEdited) {
@@ -148,14 +149,15 @@ function updateResult() {
   const row = GPU_DATA.find((r) => r.size === instanceSize);
   if (!row) return;
 
-  // Default prices from data
-  const odDefaultPrice = parsePrice(row.price);
-  const odDefaultMonthly = calculateMonthlyCost(odDefaultPrice, instanceCount);
+  // Default prices from data (per-GPU)
+  const gpuCount = typeof row.count === "string" ? parseFraction(row.count) : row.count;
+  const odDefaultGpuPrice = parsePrice(row.priceGpu);
+  const odDefaultMonthly = odDefaultGpuPrice != null ? odDefaultGpuPrice * HOURS_PER_MONTH * gpuCount * instanceCount : null;
   const odDefaultYearly = calculateYearlyCost(odDefaultMonthly);
 
-  // User-adjusted price
-  const odPrice = odUnitInput && odUnitInput.value !== "" ? parseFloat(odUnitInput.value) : odDefaultPrice;
-  const odMonthly = calculateMonthlyCost(odPrice, instanceCount);
+  // User-adjusted price (per-GPU)
+  const odGpuPrice = odUnitInput && odUnitInput.value !== "" ? parseFloat(odUnitInput.value) : odDefaultGpuPrice;
+  const odMonthly = odGpuPrice != null ? odGpuPrice * HOURS_PER_MONTH * gpuCount * instanceCount : null;
   const odYearly = calculateYearlyCost(odMonthly);
 
   if (odMonthly != null) {
@@ -175,7 +177,7 @@ function updateResult() {
     }
 
     // Show comparison if user edited OD price
-    if (odUserEdited && odDefaultPrice != null) {
+    if (odUserEdited && odDefaultGpuPrice != null) {
       setResultComparison("calc-od-result", odMonthly, odDefaultMonthly, false);
       setResultComparison("calc-od-yearly-result", odYearly, odDefaultYearly, false);
       setResultComparison("calc-od-jpy-result", convertToJpy(odMonthly, exchangeRate), convertToJpy(odDefaultMonthly, exchangeRate), true);
@@ -209,7 +211,6 @@ function updateResult() {
 
   // CB pricing
   const cbDefaultGpuPrice = parsePrice(row.priceCb);
-  const gpuCount = typeof row.count === "string" ? parseFraction(row.count) : row.count;
   const cbDefaultMonthly = cbDefaultGpuPrice != null ? cbDefaultGpuPrice * HOURS_PER_MONTH * gpuCount * instanceCount : null;
   const cbDefaultYearly = calculateYearlyCost(cbDefaultMonthly);
 
@@ -307,8 +308,8 @@ export function initCalculator() {
       odUserEdited = false;
       const row = GPU_DATA.find((r) => r.size === select?.value);
       if (row) {
-        const odPrice = parsePrice(row.price);
-        odUnitInput.value = odPrice != null ? odPrice.toFixed(2) : "";
+        const odGpuPrice = parsePrice(row.priceGpu);
+        odUnitInput.value = odGpuPrice != null ? odGpuPrice.toFixed(2) : "";
         odUnitInput.classList.remove("user-edited");
       }
       updateResult();


### PR DESCRIPTION
On-Demand単価の入力・計算をCBと同様に$/GPU/h（GPU単価ベース）に統一。

Closes #41

Generated with [Claude Code](https://claude.ai/code)