### PR TITLE
fix: correct expected value in calculateDaysCost test

### DIFF
--- a/tests/calculator.test.js
+++ b/tests/calculator.test.js
@@ -46,7 +46,7 @@ describe("calculateYearlyCost", () => {
 describe("calculateDaysCost", () => {
   it("calculates cost for specified days (24h * price * days * count)", () => {
     expect(calculateDaysCost(3.78, 30, 1)).toBeCloseTo(2721.6);
-    expect(calculateDaysCost(3.78, 182, 1)).toBeCloseTo(16504.32);
+    expect(calculateDaysCost(3.78, 182, 1)).toBeCloseTo(16511.04);
     expect(calculateDaysCost(3.78, 365, 1)).toBeCloseTo(33112.8);
     expect(calculateDaysCost(3.78, 365, 2)).toBeCloseTo(66225.6);
   });


### PR DESCRIPTION
Fix incorrect expected value in `calculateDaysCost` test that caused `npm test` to fail, blocking the Deploy to GitHub Pages workflow.

- `calculateDaysCost(3.78, 182, 1)` should equal `16511.04` (3.78 × 24 × 182), not `16504.32`

Closes #45

Generated with [Claude Code](https://claude.ai/code)