### PR TITLE
fix: ヘッダーの更新日をビルド時に自動埋め込み

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
         <p class="subtitle">
           <span data-i18n="header.subtitle">全世代のNVIDIA GPUインスタンスを一覧比較</span>
           <span> | </span>
-          <span data-i18n="header.updated">更新日</span>: 2026-01-31
+          <span data-i18n="header.updated">更新日</span>: %BUILD_DATE%
         </p>
       </div>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,21 @@
 import { defineConfig } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 
+// ビルド実行日 (JST) を index.html の %BUILD_DATE% に埋め込む
+const buildDate = new Intl.DateTimeFormat("sv-SE", {
+  timeZone: "Asia/Tokyo",
+}).format(new Date());
+
+const injectBuildDate = () => ({
+  name: "inject-build-date",
+  transformIndexHtml(html) {
+    return html.replaceAll("%BUILD_DATE%", buildDate);
+  },
+});
+
 export default defineConfig({
   root: "src",
-  plugins: [viteSingleFile()],
+  plugins: [viteSingleFile(), injectBuildDate()],
   build: {
     outDir: "../dist",
     emptyOutDir: true,


### PR DESCRIPTION
## 概要

ヘッダーの「更新日: 2026-01-31」がハードコードで、コンテンツを更新しても変わらない状態でした（PR #50 反映後も 2026-01-31 のまま）。

## 変更内容

- `src/index.html` の日付を `%BUILD_DATE%` プレースホルダーに置換
- `vite.config.js` に `transformIndexHtml` プラグインを追加し、ビルド実行日 (JST) を自動注入

これにより main へのマージ → デプロイのたびに更新日が自動で最新になります。開発サーバー (`npm run dev`) でも同様に置換されます。

## 検証

- `npm run build` → `dist/index.html` に `更新日: 2026-07-22` を確認
- `npm test`: 39件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)