### PR TITLE
feat: CB価格の自動更新ワークフローを追加

### DIFF
--- a/.github/workflows/update-cb-pricing.yml
+++ b/.github/workflows/update-cb-pricing.yml
@@ -1,0 +1,49 @@
+name: Update CB Pricing
+
+on:
+  schedule:
+    # 毎日 18:00 JST (09:00 UTC)。pricing.json 側の更新後に実行される想定
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+    types: [cb-pricing-updated]
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: update-cb-pricing
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Update CB pricing from pricing.json
+        run: node scripts/update-cb-pricing.mjs
+
+      - name: Commit and deploy if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet; then
+            echo "No pricing changes."
+            exit 0
+          fi
+          npm ci
+          npm test
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/scripts/gpu-data.js
+          git commit -m "chore: CB価格を自動更新"
+          git push
+          # GITHUB_TOKEN の push では deploy.yml が発火しないため明示的に起動する
+          gh workflow run deploy.yml --ref main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,5 @@ JSONの `instance_types.<インスタンス名>.pricing` 配列から `accelerat
 - 東京リージョン（ap-northeast-1）がある場合はその値を使用
 - ない場合は最も一般的なリージョン（us-east-1等）を使用
 - 価格は小数点第2位まで表示（例: $3.93）
+
+**この更新は自動化済み**: `.github/workflows/update-cb-pricing.yml` が毎日 18:00 JST と `repository_dispatch`（`cb-pricing-updated`）で `scripts/update-cb-pricing.mjs` を実行し、差分があれば main にコミットして deploy を起動する。手動実行は `gh workflow run update-cb-pricing.yml` または `node scripts/update-cb-pricing.mjs`。

--- a/scripts/update-cb-pricing.mjs
+++ b/scripts/update-cb-pricing.mjs
@@ -1,0 +1,71 @@
+// CB (Capacity Blocks) 価格を pricing.json から取得し、
+// src/scripts/gpu-data.js の priceCb を更新する。
+//
+// ルール (CLAUDE.md):
+// - 東京リージョン (Asia Pacific (Tokyo)) があればその値を使用
+// - ない場合は最も一般的なリージョン (us-east-1 等) を使用
+// - 価格は小数点第2位まで表示（四捨五入）
+import { readFileSync, writeFileSync } from "node:fs";
+
+const PRICING_URL =
+  "https://raw.githubusercontent.com/koyakimu/ec2-capacity-blocks-for-ml-pricing-json/refs/heads/main/data/pricing.json";
+const GPU_DATA_PATH = new URL("../src/scripts/gpu-data.js", import.meta.url);
+
+const REGION_PRIORITY = [
+  "Asia Pacific (Tokyo)",
+  "US East (N. Virginia)",
+  "US East (Ohio)",
+  "US West (Oregon)",
+];
+
+function pickRate(pricing) {
+  for (const region of REGION_PRIORITY) {
+    const entry = pricing.find((p) => p.region === region);
+    if (entry?.accelerator_hourly_rate_usd != null) {
+      return entry.accelerator_hourly_rate_usd;
+    }
+  }
+  return pricing[0]?.accelerator_hourly_rate_usd ?? null;
+}
+
+// 12.355 のような3桁小数を十進で正しく四捨五入する（浮動小数点誤差対策）
+function formatUsd(value) {
+  const cents = Math.round(Math.round(value * 1000) / 10);
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+const res = await fetch(PRICING_URL);
+if (!res.ok) {
+  console.error(`Failed to fetch pricing.json: ${res.status}`);
+  process.exit(1);
+}
+const { instance_types: instanceTypes } = await res.json();
+
+let source = readFileSync(GPU_DATA_PATH, "utf8");
+const changes = [];
+
+for (const [size, info] of Object.entries(instanceTypes)) {
+  const rate = pickRate(info.pricing ?? []);
+  if (rate == null) continue;
+  const newPrice = formatUsd(rate);
+
+  // size が一致する行の priceCb のみ書き換える（1エントリ1行の形式が前提）
+  const linePattern = new RegExp(
+    `^(.*size: "${size.replace(".", "\\.")}".*priceCb: ")(\\$[\\d.]+)(".*)$`,
+    "m",
+  );
+  source = source.replace(linePattern, (line, before, oldPrice, after) => {
+    if (oldPrice !== newPrice) {
+      changes.push(`${size}: ${oldPrice} -> ${newPrice}`);
+    }
+    return `${before}${newPrice}${after}`;
+  });
+}
+
+if (changes.length === 0) {
+  console.log("CB pricing is up to date.");
+} else {
+  writeFileSync(GPU_DATA_PATH, source);
+  console.log("Updated CB pricing:");
+  for (const change of changes) console.log(`  ${change}`);
+}


### PR DESCRIPTION
## 概要

[ec2-capacity-blocks-for-ml-pricing-json](https://github.com/koyakimu/ec2-capacity-blocks-for-ml-pricing-json) の更新に自動追従する仕組みを追加します。CB価格は `gpu-data.js` にハードコードされているため、単なる再ビルドでは反映されず、データ書き換え→コミット→デプロイの一連の自動化が必要でした。

## 変更内容

- **`scripts/update-cb-pricing.mjs`**: pricing.json を取得し、CLAUDE.md のルール（東京リージョン優先 → us-east-1 等、小数第2位に四捨五入）で `priceCb` を書き換えるスクリプト
- **`.github/workflows/update-cb-pricing.yml`**:
  - 毎日 18:00 JST（cron）+ `workflow_dispatch` + `repository_dispatch` (`cb-pricing-updated`) で実行
  - 差分があれば `npm test` を通した上で main にコミットし、`gh workflow run deploy.yml` でデプロイを起動（GITHUB_TOKEN の push では workflow が発火しないため明示起動）
- **CLAUDE.md**: 自動化済みである旨を追記

## 検証

- スクリプトをローカル実行: 現在値と一致で「up to date」、値を旧価格に戻して再実行すると正しく検出・復元されることを確認
- `npm test`: 39件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)